### PR TITLE
Make sure goreleaser uses cosign to sign images

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,7 +4,6 @@ project_name: poutine
 before:
   hooks:
     - go mod verify
-    - go mod tidy
 
 builds:
   - env:
@@ -12,6 +11,12 @@ builds:
     goos:
       - linux
       - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - '7'
 
 kos:
   - repository: ghcr.io/boostsecurityio/poutine
@@ -24,6 +29,13 @@ kos:
     platforms:
       - linux/amd64
       - linux/arm64
+
+docker_signs:
+  - artifacts: manifests
+    args:
+      - "sign"
+      - "${artifact}"
+      - "--yes" # skip user interaction
 
 signs:
   - cmd: cosign


### PR DESCRIPTION
https://goreleaser.com/customization/ko/?h=kos#signing-ko-manifests

Similar to how Chainguard did it here https://github.com/chainguard-dev/clank/blob/main/.goreleaser.yml#L56-L82

Drive-by: 
- Do not `go mod tidy`, this can mutate the `go.mod`, which is detected by Harden Runner , yay!
- Avoid building `i386`