### PR TITLE
Add GitHub Action and self-test

### DIFF
--- a/.github/workflows/pop.yml
+++ b/.github/workflows/pop.yml
@@ -1,0 +1,35 @@
+name: POP - poutine on poutine
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - .github/workflows/**
+      - action.yml
+  pull_request:
+    branches: [ main ]
+    paths:
+      - .github/workflows/**
+      - action.yml
+
+permissions:
+  security-events: write
+  contents: read
+
+jobs:
+  pop:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+      with:
+        disable-sudo: true
+        egress-policy: block
+        allowed-endpoints: >
+          github.com:443
+          api.github.com:443
+          codeload.github.com:443
+          objects.githubusercontent.com:443
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: ./
+      name: "Run poutine on poutine's own codebase"
+      id: self-test

--- a/.github/workflows/pop.yml
+++ b/.github/workflows/pop.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
       with:
         disable-sudo: true
-        egress-policy: block
+        egress-policy: audit
         allowed-endpoints: >
           github.com:443
           api.github.com:443

--- a/.github/workflows/pop.yml
+++ b/.github/workflows/pop.yml
@@ -36,6 +36,6 @@ jobs:
       id: self-test
 
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3.24.10
       with:
         sarif_file: results.sarif

--- a/.github/workflows/pop.yml
+++ b/.github/workflows/pop.yml
@@ -2,6 +2,11 @@ name: POP - poutine on poutine
 
 on:
   push:
+    branches: [ main ]
+    paths:
+      - .github/workflows/**
+      - action.yml
+
   pull_request:
     branches: [ main ]
     paths:
@@ -29,3 +34,6 @@ jobs:
     - uses: ./
       name: "Run poutine on poutine's own codebase"
       id: self-test
+
+    - name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/pop.yml
+++ b/.github/workflows/pop.yml
@@ -2,10 +2,6 @@ name: POP - poutine on poutine
 
 on:
   push:
-    branches: [ main ]
-    paths:
-      - .github/workflows/**
-      - action.yml
   pull_request:
     branches: [ main ]
     paths:

--- a/.github/workflows/pop.yml
+++ b/.github/workflows/pop.yml
@@ -37,3 +37,5 @@ jobs:
 
     - name: Upload SARIF file
       uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: results.sarif

--- a/Dockerfile.action
+++ b/Dockerfile.action
@@ -1,0 +1,5 @@
+FROM ghcr.io/boostsecurityio/poutine:0.9.7@sha256:034326fac021cbedf8df99e90d993ec3553c7649395040bbb8bca05b601de35a
+
+USER root
+
+ENTRYPOINT ["/bin/sh", "-c"]

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,7 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://ghcr.io/boostsecurityio/poutine:0.9.7@sha256:034326fac021cbedf8df99e90d993ec3553c7649395040bbb8bca05b601de35a
-  entrypoint: /bin/sh
+  image: Dockerfile.action
   args:
-    - -c
     - |
         poutine -format "$INPUT_FORMAT" analyze_local "$GITHUB_WORKSPACE" > "$INPUT_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -17,4 +17,5 @@ runs:
   image: Dockerfile.action
   args:
     - |
+        git config --global --add safe.directory /src
         poutine -format "$INPUT_FORMAT" analyze_local "$GITHUB_WORKSPACE" > "$INPUT_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -4,45 +4,19 @@ description: |
   Designed to streamline security analysis, poutine scans your repository’s CI/CD pipelines.
   It offers insights to secure your software supply chain efficiently.
 inputs:
-  path:
-    description: 'Path to the local repository to analyze.'
+  format:
+    description: 'Report format'
+    default: sarif
     required: true
-    default: '.'
+  output:
+    description: 'Report file output'
+    default: results.sarif
+    required: true
 runs:
-  using: composite
-  steps:
-    - name: Download and Setup
-      id: setup
-      shell: bash
-      env:
-        PINNED_VERSION: v0.9.3
-        PINNED_ARCH: poutine_Linux_x86_64.tar.gz
-        PINNED_HASH: 938c36de89eea18d69c8d5605a64ef1573e682cfd02b61d4cc2de3b0663a63bc
-      run: |
-        # Create a temp dir for the tool and its results
-        POUTINE_TOOL_DIR=$(mktemp -d)
-        cd "${POUTINE_TOOL_DIR}"
-        echo "POUTINE_TOOL_DIR=${POUTINE_TOOL_DIR}" >> "${GITHUB_ENV}"
-        
-        # Download tool archive and verify checksum
-        curl -sLO "https://github.com/boostsecurityio/poutine/releases/download/${PINNED_VERSION}/${PINNED_ARCH}"
-        echo "${PINNED_HASH}  ${PINNED_ARCH}" | shasum -a 256 --check
-        
-        # Decompress the tool
-        tar -xzf "${PINNED_ARCH}"
-        
-    - name: Analyze the repository
-      id: analyze
-      shell: bash
-      run: |
-        POUTINE_SARIF_FILE="${POUTINE_TOOL_DIR}/results.sarif"
-        echo "POUTINE_SARIF_FILE=${POUTINE_SARIF_FILE}" >> "${GITHUB_ENV}"
-        "${POUTINE_TOOL_DIR}/poutine" -format sarif analyze_local "${TARGET_PATH}" > "${POUTINE_SARIF_FILE}"
-      env:
-        TARGET_PATH: ${{ inputs.path }}
-
-    - name: Upload SARIF Findings
-      id: upload
-      uses: github/codeql-action/upload-sarif@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3.24.10
-      with:
-        sarif_file: ${{ env.POUTINE_SARIF_FILE }}
+  using: docker
+  image: docker://ghcr.io/boostsecurityio/poutine:0.9.7@sha256:034326fac021cbedf8df99e90d993ec3553c7649395040bbb8bca05b601de35a
+  entrypoint: /bin/sh
+  args:
+    - -c
+    - |
+        poutine -format "$INPUT_FORMAT" analyze_local "$GITHUB_WORKSPACE" > "$INPUT_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ runs:
   image: Dockerfile.action
   args:
     - |
-        git config --global --add safe.directory /src
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
         poutine -format "$INPUT_FORMAT" analyze_local "$GITHUB_WORKSPACE" > "$INPUT_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,48 @@
+name: poutine - GitHub Actions SAST
+description: |
+  BoostSecurity.io’s poutine detects vulnerabilities and misconfigurations in your GitHub Actions workflows.
+  Designed to streamline security analysis, poutine scans your repository’s CI/CD pipelines.
+  It offers insights to secure your software supply chain efficiently.
+inputs:
+  path:
+    description: 'Path to the local repository to analyze.'
+    required: true
+    default: '.'
+runs:
+  using: composite
+  steps:
+    - name: Download and Setup
+      id: setup
+      shell: bash
+      env:
+        PINNED_VERSION: v0.9.3
+        PINNED_ARCH: poutine_Linux_x86_64.tar.gz
+        PINNED_HASH: 938c36de89eea18d69c8d5605a64ef1573e682cfd02b61d4cc2de3b0663a63bc
+      run: |
+        # Create a temp dir for the tool and its results
+        POUTINE_TOOL_DIR=$(mktemp -d)
+        cd "${POUTINE_TOOL_DIR}"
+        echo "POUTINE_TOOL_DIR=${POUTINE_TOOL_DIR}" >> "${GITHUB_ENV}"
+        
+        # Download tool archive and verify checksum
+        curl -sLO "https://github.com/boostsecurityio/poutine/releases/download/${PINNED_VERSION}/${PINNED_ARCH}"
+        echo "${PINNED_HASH}  ${PINNED_ARCH}" | shasum -a 256 --check
+        
+        # Decompress the tool
+        tar -xzf "${PINNED_ARCH}"
+        
+    - name: Analyze the repository
+      id: analyze
+      shell: bash
+      run: |
+        POUTINE_SARIF_FILE="${POUTINE_TOOL_DIR}/results.sarif"
+        echo "POUTINE_SARIF_FILE=${POUTINE_SARIF_FILE}" >> "${GITHUB_ENV}"
+        "${POUTINE_TOOL_DIR}/poutine" -format sarif analyze_local "${TARGET_PATH}" > "${POUTINE_SARIF_FILE}"
+      env:
+        TARGET_PATH: ${{ inputs.path }}
+
+    - name: Upload SARIF Findings
+      id: upload
+      uses: github/codeql-action/upload-sarif@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3.24.10
+      with:
+        sarif_file: ${{ env.POUTINE_SARIF_FILE }}


### PR DESCRIPTION
- Add GitHub Action to simplify usage of `poutine`.
- Add self-test with a pinned version
- Make sure the action can be used with a harden-runner block config