### PR TITLE
output the rule severity in pretty print

### DIFF
--- a/formatters/pretty/pretty.go
+++ b/formatters/pretty/pretty.go
@@ -44,6 +44,7 @@ func printFindingsPerRule(out io.Writer, results map[string][]opa.Finding, rules
 		table.SetHeader([]string{"Repository", "Details", "URL"})
 
 		fmt.Fprintf(out, "Rule: %s\n", rules[ruleId].Title)
+		fmt.Fprintf(out, "Severity: %s\n", rules[ruleId].Level)
 		fmt.Fprintf(out, "Description: %s\n", rules[ruleId].Description)
 		fmt.Fprintf(out, "Documentation: https://github.com/boostsecurityio/poutine/blob/main/docs/content/en/rules/%s.md\n\n", ruleId)
 


### PR DESCRIPTION
output the raw SARIF result level into the pretty print output to help contextualize the severity of the findings