### PR TITLE
add docs module and add documentation to SARIF

### DIFF
--- a/docs/content.go
+++ b/docs/content.go
@@ -1,0 +1,50 @@
+package docs
+
+import (
+	"embed"
+	"fmt"
+	"path"
+	"strings"
+)
+
+//go:embed content
+var content embed.FS
+
+type Page struct {
+	Content string `yaml:"-"`
+}
+
+func GetPagesContent() map[string]string {
+	docs := map[string]string{}
+	entries, err := content.ReadDir(path.Join("content", "en", "rules"))
+	if err != nil {
+		return docs
+	}
+
+	for _, entry := range entries {
+		ruleId := strings.TrimSuffix(entry.Name(), ".md")
+		page, err := GetPage(ruleId)
+		if err != nil {
+			continue
+		}
+
+		docs[ruleId] = page.Content
+	}
+
+	return docs
+}
+
+func GetPage(ruleId string) (*Page, error) {
+	doc, err := content.ReadFile(
+		path.Join("content", "en", "rules", ruleId+".md"))
+	if err != nil {
+		return nil, err
+	}
+
+	parts := strings.SplitAfterN(string(doc), "---\n", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid doc page %s.md", ruleId)
+	}
+
+	return &Page{Content: strings.TrimSpace(parts[2])}, nil
+}

--- a/docs/content_test.go
+++ b/docs/content_test.go
@@ -1,0 +1,18 @@
+package docs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRuleDocs(t *testing.T) {
+	page, err := GetPage("debug_enabled")
+
+	assert.Nil(t, err)
+	assert.True(t,
+		strings.HasPrefix(page.Content, "## Description"),
+		"content should be trimmed '%s'...", page.Content[0:10],
+	)
+}


### PR DESCRIPTION
add the docs to the SARIF output format so it looks pretty in VS Code/code scanning alerts

![image](https://github.com/boostsecurityio/poutine/assets/172889/8522b37c-8553-4240-83ae-30e711b2ed80)
