### PR TITLE
fix untrusted_checkout_exec line numbers

### DIFF
--- a/opa/rego/rules/untrusted_checkout_exec.rego
+++ b/opa/rego/rules/untrusted_checkout_exec.rego
@@ -37,7 +37,7 @@ build_commands[cmd] = {
 
 results contains poutine.finding(rule, pkg_purl, {
 	"path": workflow_path,
-	"line": step.line,
+	"line": step.lines.run,
 	"details": sprintf("Detected usage of `%s`", [cmd]),
 }) if {
 	[pkg_purl, workflow_path, step] := _steps_after_untrusted_checkout[_]
@@ -49,7 +49,7 @@ results contains poutine.finding(rule, pkg_purl, {
 
 results contains poutine.finding(rule, pkg_purl, {
 	"path": workflow_path,
-	"line": step.line,
+	"line": step.lines.uses,
 	"details": sprintf("Detected usage the GitHub Action `%s`", [step.action]),
 }) if {
 	[pkg_purl, workflow_path, step] := _steps_after_untrusted_checkout[_]

--- a/scanner/inventory_test.go
+++ b/scanner/inventory_test.go
@@ -145,7 +145,7 @@ func TestFindings(t *testing.T) {
 			Purl:   purl,
 			Meta: opa.FindingMeta{
 				Path:    ".github/workflows/valid.yml",
-				Line:    29,
+				Line:    30,
 				Details: "Detected usage of `npm`",
 			},
 		},
@@ -154,7 +154,7 @@ func TestFindings(t *testing.T) {
 			Purl:   purl,
 			Meta: opa.FindingMeta{
 				Path:    ".github/workflows/valid.yml",
-				Line:    55,
+				Line:    56,
 				Details: "Detected usage the GitHub Action `bridgecrewio/checkov-action`",
 			},
 		},
@@ -163,7 +163,7 @@ func TestFindings(t *testing.T) {
 			Purl:   purl,
 			Meta: opa.FindingMeta{
 				Path:    ".github/workflows/valid.yml",
-				Line:    59,
+				Line:    60,
 				Details: "Detected usage of `pre-commit`",
 			},
 		},


### PR DESCRIPTION
report the `run:` line if the build command is in bash script or the `uses:` line if it's an action