### PR TITLE
adjust sarif for github code scanning alerts

### DIFF
--- a/formatters/sarif/sarif.go
+++ b/formatters/sarif/sarif.go
@@ -73,16 +73,17 @@ func (f *Format) Format(ctx context.Context, report *opa.FindingsResult, package
 				line = 1
 			}
 			ruleDoc := docs[ruleId]
+			ruleUrl := fmt.Sprintf("https://github.com/boostsecurityio/poutine/tree/main/docs/content/en/rules/%s.md", ruleId)
 
 			run.AddRule(ruleId).
 				WithName(rule.Title).
 				WithDescription(rule.Title).
 				WithFullDescription(
-					sarif.NewMarkdownMultiformatMessageString(ruleDoc),
+					sarif.NewMultiformatMessageString(ruleDescription),
 				).
-				WithHelpURI(
-					fmt.Sprintf("https://github.com/boostsecurityio/poutine/tree/main/docs/content/en/rules/%s.md", ruleId),
-				)
+				WithHelpURI(ruleUrl).
+				WithTextHelp(ruleUrl).
+				WithMarkdownHelp(ruleDoc)
 
 			run.AddDistinctArtifact(path)
 


### PR DESCRIPTION
- the markdown documentation need to be in results help to show up in code scanning alerts
  - help.text is set as the rule URL. it is not shown if help.markdown is set
- use the result description from before #23 because it breaks the SARIF upload to Github


![image](https://github.com/boostsecurityio/poutine/assets/172889/366be635-072c-4443-a197-54ecbf2cc2ef)

