### PR TITLE
adjust self-hosted runner regex

### DIFF
--- a/opa/rego/poutine/utils.rego
+++ b/opa/rego/poutine/utils.rego
@@ -46,7 +46,7 @@ job_uses_self_hosted_runner(job) if {
 	run_on := job.runs_on[_]
 	not contains(run_on, "$") # skip expressions
 	not regex.match(
-		"(?i)^((ubuntu-((18|20|22)\\.04|latest)|macos-(11|12|13|latest)(-xl)?|windows-(20[0-9]{2}|latest)|(buildjet|warp|)-[a-z0-9-]+))$",
+		"(?i)^((ubuntu-(([0-9]{2})\\.04|latest)|macos-([0-9]{2}|latest)(-x?large)?|windows-(20[0-9]{2}|latest)|(buildjet|warp)-[a-z0-9-]+))$",
 		run_on,
 	)
 }

--- a/scanner/testdata/.github/workflows/secrets.yaml
+++ b/scanner/testdata/.github/workflows/secrets.yaml
@@ -1,4 +1,4 @@
-on: push
+on: pull_request
 
 jobs:
   matrix:
@@ -14,7 +14,7 @@ jobs:
           token: ${{ secrets[format('SECRET_%s', matrix.env)] }}
 
   json:
-    runs-on: ubuntu-latest
+    runs-on: macos-14-xlarge
     env:
       SECRETS: ${{ toJSON(secrets) }}
     steps:


### PR DESCRIPTION
consider any numerical versions as hosted runners. 

fix #16 