### PR TITLE
Improving OSSF Scorecard score - Part 1

### DIFF
--- a/.github/workflows/pop.yml
+++ b/.github/workflows/pop.yml
@@ -13,13 +13,14 @@ on:
       - .github/workflows/**
       - action.yml
 
-permissions:
-  security-events: write
-  contents: read
+permissions: {}
 
 jobs:
   pop:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
     - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
       with:


### PR DESCRIPTION
As of this writing, https://securityscorecards.dev/viewer/?uri=github.com%2Fboostsecurityio%2Fpoutine:

```
Reason
detected GitHub workflow tokens with excessive permissions
Details
Warn: topLevel 'security-events' permission set to 'write': .github/workflows/pop.yml:17
Warn: topLevel 'contents' permission set to 'write': .github/workflows/release.yml:15
Warn: topLevel 'packages' permission set to 'write': .github/workflows/release.yml:16
```