### PR TITLE
add reusable workflows to the build inventory

### DIFF
--- a/opa/rego/poutine/inventory/github_actions.rego
+++ b/opa/rego/poutine/inventory/github_actions.rego
@@ -1,15 +1,17 @@
 package poutine.inventory
 
-import future.keywords.contains
+import rego.v1
 
-build_dependencies contains dep {
+import data.poutine.utils
+
+build_dependencies contains dep if {
 	pkg := input.packages[_]
 	step := pkg.github_actions_workflows[_].jobs[_].steps[_]
 
 	dep := purl.parse_github_actions(step.uses)
 }
 
-build_dependencies contains dep {
+build_dependencies contains dep if {
 	pkg := input.packages[_]
 	job := pkg.github_actions_workflows[_].jobs[_]
 	image := job.container.image
@@ -17,14 +19,23 @@ build_dependencies contains dep {
 	dep := purl.parse_docker_image(image)
 }
 
-package_dependencies contains dep {
+build_dependencies contains dep if {
+	pkg := input.packages[_]
+	job := pkg.github_actions_workflows[_].jobs[_]
+	uses := job.uses
+	not utils.empty(uses)
+
+	dep := purl.parse_github_actions(uses)
+}
+
+package_dependencies contains dep if {
 	pkg := input.packages[_]
 	step := pkg.github_actions_metadata[_].runs.steps[_]
 
 	dep := purl.parse_github_actions(step.uses)
 }
 
-package_dependencies contains dep {
+package_dependencies contains dep if {
 	pkg := input.packages[_]
 	runs := pkg.github_actions_metadata[_].runs
 

--- a/scanner/inventory_test.go
+++ b/scanner/inventory_test.go
@@ -42,10 +42,11 @@ func TestPurls(t *testing.T) {
 		"pkg:githubactions/org/repo@main",
 		"pkg:docker/debian%3Avuln",
 		"pkg:githubactions/bridgecrewio/checkov-action@main",
+		"pkg:githubactions/org/repo@main#.github/workflows/Reusable.yml",
 	}
 	assert.ElementsMatch(t, i.Purls(), purls)
 	assert.Equal(t, 1, len(i.Packages))
-	assert.Equal(t, 15, len(i.Packages[0].BuildDependencies))
+	assert.Equal(t, 16, len(i.Packages[0].BuildDependencies))
 	assert.Equal(t, 4, len(i.Packages[0].PackageDependencies))
 }
 

--- a/scanner/testdata/.github/workflows/reusable.yml
+++ b/scanner/testdata/.github/workflows/reusable.yml
@@ -13,3 +13,13 @@ jobs:
       - uses: actions/checkout@main
         with:
           ref: ${{ inputs.ref }}
+
+  uses:
+    runs-on: ubuntu-latest
+    uses: org/repo/.github/workflows/Reusable.yml@main
+    with:
+      ref: ${{ inputs.ref }}
+
+  local-uses:
+    runs-on: ubuntu-latest
+    uses: ./.github/workflows/ci.yml


### PR DESCRIPTION
- Parse job.uses as a github actions purl and add it to the build inventory. 
- Adjust inventory/github_actions.rego with rego.v1 syntax