### PR TITLE
Opa config

### DIFF
--- a/models/config.go
+++ b/models/config.go
@@ -1,0 +1,17 @@
+package models
+
+type ConfigSkip struct {
+	Purl  string `json:"purl,omitempty"`
+	Path  string `json:"path,omitempty"`
+	Rule  string `json:"rule,omitempty"`
+	OsvId string `json:"osv_id,omitempty"`
+	Job   string `json:"job,omitempty"`
+}
+
+type Config struct {
+	Skip []ConfigSkip `json:"skip"`
+}
+
+func DefaultConfig() *Config {
+	return &Config{}
+}

--- a/models/config.go
+++ b/models/config.go
@@ -1,11 +1,12 @@
 package models
 
 type ConfigSkip struct {
-	Purl  string `json:"purl,omitempty"`
-	Path  string `json:"path,omitempty"`
-	Rule  string `json:"rule,omitempty"`
-	OsvId string `json:"osv_id,omitempty"`
-	Job   string `json:"job,omitempty"`
+	Purl  StringList `json:"purl,omitempty"`
+	Path  StringList `json:"path,omitempty"`
+	Rule  StringList `json:"rule,omitempty"`
+	OsvId StringList `json:"osv_id,omitempty"`
+	Job   StringList `json:"job,omitempty"`
+	Level StringList `json:"level,omitempty"`
 }
 
 type Config struct {

--- a/opa/opa.go
+++ b/opa/opa.go
@@ -11,7 +11,7 @@ import (
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/topdown/print"
-
+	"github.com/rs/zerolog/log"
 	"io/fs"
 )
 
@@ -62,7 +62,7 @@ func NewOpa() (*Opa, error) {
 }
 
 func (o *Opa) Print(ctx print.Context, s string) error {
-	fmt.Println(s)
+	log.Debug().Ctx(ctx.Context).Str("location", ctx.Location.String()).Msg(s)
 	return nil
 }
 

--- a/opa/opa_test.go
+++ b/opa/opa_test.go
@@ -142,14 +142,14 @@ func TestWithConfig(t *testing.T) {
 	err = o.WithConfig(ctx, &models.Config{
 		Skip: []models.ConfigSkip{
 			{
-				Path: "action.yaml",
+				Path: []string{"action.yaml"},
 			},
 		},
 	})
 	assert.NoError(t, err)
 
 	var result string
-	err = o.Eval(ctx, "data.config.skip[_].path", nil, &result)
+	err = o.Eval(ctx, "data.config.skip[_].path[_]", nil, &result)
 
 	noOpaErrors(t, err)
 	assert.Equal(t, "action.yaml", result)

--- a/opa/opa_test.go
+++ b/opa/opa_test.go
@@ -2,6 +2,7 @@ package opa
 
 import (
 	"context"
+	"github.com/boostsecurityio/poutine/models"
 	"github.com/open-policy-agent/opa/ast"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +17,6 @@ func noOpaErrors(t *testing.T, err error) {
 	if regoErrors, ok := err.(*ast.Errors); ok {
 		for _, e := range *regoErrors {
 			t.Errorf("ast error: %v", e)
-
 		}
 	}
 
@@ -132,4 +132,25 @@ func TestJobUsesSelfHostedRunner(t *testing.T) {
 		noOpaErrors(t, err)
 		assert.Equal(t, expected, result, "runner: "+runner)
 	}
+}
+
+func TestWithConfig(t *testing.T) {
+	o, err := NewOpa()
+	noOpaErrors(t, err)
+	ctx := context.TODO()
+
+	err = o.WithConfig(ctx, &models.Config{
+		Skip: []models.ConfigSkip{
+			{
+				Path: "action.yaml",
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	var result string
+	err = o.Eval(ctx, "data.config.skip[_].path", nil, &result)
+
+	noOpaErrors(t, err)
+	assert.Equal(t, "action.yaml", result)
 }

--- a/opa/rego/poutine/queries/findings.rego
+++ b/opa/rego/poutine/queries/findings.rego
@@ -1,10 +1,31 @@
 package poutine.queries.findings
 
 import data.rules
+import rego.v1
 
 rules_by_id[id] = rules[id].rule
 
+skip(f) if {
+	s := data.config.skip[_]
+	o := object.union(
+		{
+			"purl": f.purl,
+			"rule": f.rule_id,
+			"level": rules_by_id[rule_id].level,
+		},
+		object.filter(f.meta, {"osv_id", "job", "path"}),
+	)
+
+	[attr | s[attr]; not o[attr] in s[attr]] == []
+}
+
+findings contains finding if {
+	finding := rules[rule_id].results[_]
+
+	not skip(finding)
+}
+
 result = {
-	"findings": [f | f := rules[rule_id].results[_]],
+	"findings": findings,
 	"rules": rules_by_id,
 }


### PR DESCRIPTION
- Allow the OPA instance to be configured to skip rules and findings.
- Make `print` in Rego use the debug logger instead of stdout.
