### PR TITLE
fix running poutine without a config file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,7 +119,7 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		viper.AddConfigPath(".")
-		viper.SetConfigFile(".poutine.yml")
+		viper.SetConfigName(".poutine")
 	}
 
 	if err := viper.ReadInConfig(); err != nil {


### PR DESCRIPTION
In this repo if you delete the file .poutine.yml and run poutine you get the following error:

```shell
$ go run . analyze_local .
{"level":"error","error":"open .poutine.yml: no such file or directory","time":"2024-05-09T11:44:21-04:00","message":"Can't read config"}
```

Viper does not return a viper.ConfigFileNotFoundError if viper.SetConfigFile is used. 