### PR TITLE
Add Error for Empty Organization

### DIFF
--- a/analyze/analyze.go
+++ b/analyze/analyze.go
@@ -282,6 +282,11 @@ func (a *Analyzer) finalizeAnalysis(ctx context.Context, inventory *scanner.Inve
 		return err
 	}
 
+	if len(report.Findings) == 0 {
+		log.Info().Msg("No results returned by analysis")
+		return nil
+	}
+
 	err = a.Formatter.Format(ctx, report, inventory.Packages)
 	if err != nil {
 		return err

--- a/providers/github/client.go
+++ b/providers/github/client.go
@@ -271,6 +271,12 @@ func (c *Client) GetOrgRepos(ctx context.Context, org string) <-chan analyze.Rep
 				return
 			}
 
+			if query.RepositoryOwner.Repositories.TotalCount == 0 {
+				log.Error().Msgf("No repositories found for org %s", org)
+				batchChan <- analyze.RepoBatch{Err: fmt.Errorf("no repositories found for org %s", org)}
+				return
+			}
+
 			totalCount := 0
 			if !totalCountSent {
 				totalCount = query.RepositoryOwner.Repositories.TotalCount


### PR DESCRIPTION
Added Error that could indicate improper auth or a typo in the org name. Added skipping of printing the results if no findings are present