### PR TITLE
gitlab: fix parsing error on scalar includes

### DIFF
--- a/models/gitlab.go
+++ b/models/gitlab.go
@@ -324,7 +324,7 @@ func (o *GitlabciIncludeItems) UnmarshalYAML(node *yaml.Node) error {
 		if err := node.Decode(&includes); err != nil {
 			return err
 		}
-	case yaml.MappingNode:
+	case yaml.MappingNode, yaml.ScalarNode:
 		var include GitlabciIncludeItem
 		if err := node.Decode(&include); err != nil {
 			return err

--- a/models/gitlab_test.go
+++ b/models/gitlab_test.go
@@ -139,3 +139,73 @@ deploy:
 	assert.Equal(t, "main", config.Include[3].Ref)
 	assert.Equal(t, "/templates/.gitlab-ci-template.yml", config.Include[3].File[0])
 }
+
+func TestGitlabIncludes(t *testing.T) {
+	subjects := []struct {
+		config   string
+		expected GitlabciIncludeItems
+	}{
+		{
+			config: `include: https://example.com`,
+			expected: []GitlabciIncludeItem{
+				{Remote: "https://example.com"},
+			},
+		},
+		{
+			config: `include: local.yml`,
+			expected: []GitlabciIncludeItem{
+				{Local: "local.yml"},
+			},
+		},
+		{
+			config: `include: [https://example.com]`,
+			expected: []GitlabciIncludeItem{
+				{Remote: "https://example.com"},
+			},
+		},
+		{
+			config: `include: [local.yml]`,
+			expected: []GitlabciIncludeItem{
+				{Local: "local.yml"},
+			},
+		},
+		{
+			config: `include: [{local: local.yml}]`,
+			expected: []GitlabciIncludeItem{
+				{Local: "local.yml"},
+			},
+		},
+		{
+			config: `include: [{remote: http://example.com}]`,
+			expected: []GitlabciIncludeItem{
+				{Remote: "http://example.com"},
+			},
+		},
+		{
+			config: `include: [{template: Auto-DevOps.gitlab-ci.yml}]`,
+			expected: []GitlabciIncludeItem{
+				{Template: "Auto-DevOps.gitlab-ci.yml"},
+			},
+		},
+		{
+			config: `include: [{project: my-group/my-project, ref: main, file: /templates/.gitlab-ci-template.yml}]`,
+			expected: []GitlabciIncludeItem{
+				{
+					Project: "my-group/my-project",
+					Ref:     "main",
+					File:    []string{"/templates/.gitlab-ci-template.yml"},
+				},
+			},
+		},
+		{
+			config:   `{}`,
+			expected: nil,
+		},
+	}
+
+	for _, subject := range subjects {
+		config, err := ParseGitlabciConfig([]byte(subject.config))
+		assert.Nil(t, err)
+		assert.Equal(t, subject.expected, config.Include)
+	}
+}


### PR DESCRIPTION
```
git clone --depth=1 https://gitlab.gnome.org/GNOME/gimp.git
go run . analyze_local --scm gitlab gimp --format json | jq | grep include
```

now properly includes `pkg:gitlabci/include/remote?download_url=https%3A%2F%2Fgitlab.gnome.org%2FGNOME%2Fcitemplates%2Fraw%2Fmaster%2Fflatpak%2Fflatpak_ci_initiative.yml` in the build inventory