### PR TITLE
Fix GitHub Action workflows paths / paths-ignore

### DIFF
--- a/.github/workflows/pop.yml
+++ b/.github/workflows/pop.yml
@@ -12,11 +12,10 @@ on:
     paths:
       - .github/workflows/**
       - action.yml
-    paths-ignore:
-      - 'README.md'
-      - 'LICENSE'
-      - 'docs/**'
-      - '.github/**'
+      - '!README.md'
+      - '!LICENSE'
+      - '!docs/**'
+      - '!.github/**'
 
 permissions: {}
 


### PR DESCRIPTION
You cannot have both `paths` and `paths-ignore`
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore