### PR TITLE
Add context to fatal errors in `analyze.AnalyzeOrg`

### DIFF
--- a/analyze/analyze.go
+++ b/analyze/analyze.go
@@ -138,13 +138,13 @@ func (a *Analyzer) AnalyzeOrg(ctx context.Context, org string, numberOfGoroutine
 
 				pkg, err := a.generatePackageInsights(ctx, tempDir, repo)
 				if err != nil {
-					errChan <- err
+					errChan <- fmt.Errorf("failed to generate package insights for repo repoNameWithOwner: %w", err)
 					return
 				}
 
 				err = inventory.AddPackage(ctx, pkg, tempDir)
 				if err != nil {
-					errChan <- err
+					errChan <- fmt.Errorf("failed to add package for repo repoNameWithOwner: %w", err)
 					return
 				}
 				_ = bar.Add(1)

--- a/analyze/analyze.go
+++ b/analyze/analyze.go
@@ -138,13 +138,13 @@ func (a *Analyzer) AnalyzeOrg(ctx context.Context, org string, numberOfGoroutine
 
 				pkg, err := a.generatePackageInsights(ctx, tempDir, repo)
 				if err != nil {
-					errChan <- fmt.Errorf("failed to generate package insights for repo repoNameWithOwner: %w", err)
+					errChan <- fmt.Errorf("failed to generate package insights for repo %s: %w", repoNameWithOwner, err)
 					return
 				}
 
 				err = inventory.AddPackage(ctx, pkg, tempDir)
 				if err != nil {
-					errChan <- fmt.Errorf("failed to add package for repo repoNameWithOwner: %w", err)
+					errChan <- fmt.Errorf("failed to add package for repo %s: %w", repoNameWithOwner, err)
 					return
 				}
 				_ = bar.Add(1)


### PR DESCRIPTION
When analyzing repos in an org, `generatePackageInsights` and `AddPackage` produce fatal errors that will prevent the analysis from continuing. Currently, the errors are confusing as they do not reveal which repos caused the failure (partially related to #101). This PR wraps those errors to provide context.

```
Analyzing repositories  99% |███████████████████████████████████████ | (5796/5799) [44m29s:1s]Error: failed to analyze org large-org: failed to get head branch name: exit status 128
Usage:
  poutine analyze_org [flags]

Flags:
  -h, --help           help for analyze_org
  -i, --ignore-forks   Ignore forked repositories in the organization
  -j, --threads int    Parallelization factor for scanning organizations (default 2)
  -t, --token string   SCM access token (env: GH_TOKEN)

Global Flags:
      --config string         config file (default is .poutine.yml in the current directory)
  -f, --format string         Output format (pretty, json, sarif) (default "pretty")
  -s, --scm string            SCM platform (github, gitlab) (default "github")
  -b, --scm-base-url string   Base URI of the self-hosted SCM instance (optional)
  -v, --verbose               Enable verbose logging

9:27PM | ERROR | error="failed to analyze org large-org: failed to get head branch name: exit status 128"
```
