### PR TITLE
Change doc links to GitHub pages

### DIFF
--- a/formatters/pretty/pretty.go
+++ b/formatters/pretty/pretty.go
@@ -52,7 +52,7 @@ func printFindingsPerRule(out io.Writer, results map[string][]opa.Finding, rules
 		fmt.Fprintf(out, "Rule: %s\n", rules[ruleId].Title)
 		fmt.Fprintf(out, "Severity: %s\n", rules[ruleId].Level)
 		fmt.Fprintf(out, "Description: %s\n", rules[ruleId].Description)
-		fmt.Fprintf(out, "Documentation: https://github.com/boostsecurityio/poutine/blob/main/docs/content/en/rules/%s.md\n\n", ruleId)
+		fmt.Fprintf(out, "Documentation: https://boostsecurityio.github.io/poutine/rules/%s\n\n", ruleId)
 
 		for _, finding := range results[ruleId] {
 			purl, _ := models.NewPurl(finding.Purl)


### PR DESCRIPTION
This updates the documentation links to use GitHub pages.

e.g., https://github.com/boostsecurityio/poutine/blob/main/docs/content/en/rules/debug_enabled.md -> https://boostsecurityio.github.io/poutine/rules/debug_enabled/

(Assuming that this is the intention behind the GH pages site.)