### PR TITLE
fix debug_enabled on steps and error handling

### DIFF
--- a/analyze/analyze.go
+++ b/analyze/analyze.go
@@ -163,8 +163,6 @@ func (a *Analyzer) AnalyzeOrg(ctx context.Context, org string, numberOfGoroutine
 		}
 	}
 
-	fmt.Print("\n\n")
-
 	return a.finalizeAnalysis(ctx, inventory)
 }
 

--- a/analyze/analyze.go
+++ b/analyze/analyze.go
@@ -138,13 +138,13 @@ func (a *Analyzer) AnalyzeOrg(ctx context.Context, org string, numberOfGoroutine
 
 				pkg, err := a.generatePackageInsights(ctx, tempDir, repo)
 				if err != nil {
-					errChan <- err
+					log.Error().Err(err).Str("repo", repoNameWithOwner).Msg("failed to generate package insights")
 					return
 				}
 
 				err = inventory.AddPackage(ctx, pkg, tempDir)
 				if err != nil {
-					errChan <- err
+					log.Error().Err(err).Str("repo", repoNameWithOwner).Msg("failed to add package to inventory")
 					return
 				}
 				_ = bar.Add(1)

--- a/opa/models.go
+++ b/opa/models.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"strconv"
 )
 
@@ -60,7 +61,8 @@ func (m *FindingMeta) UnmarshalJSON(data []byte) error {
 		meta: (*meta)(m),
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
+		log.Error().RawJSON("meta", data).Err(err).Msg("failed to unmarshal FindingMeta")
+		return nil
 	}
 	m.Step = aux.Step.String()
 	return nil

--- a/opa/rego/rules/debug_enabled.rego
+++ b/opa/rego/rules/debug_enabled.rego
@@ -44,9 +44,9 @@ _gitlab_debug_enabled[[pkg.purl, config.path]] contains var.name if {
 
 _github_actions_debug_env_vars := {"ACTIONS_STEP_DEBUG", "ACTIONS_RUNNER_DEBUG"}
 
-is_debug_enabled(var) = true if {
-    var.name in _github_actions_debug_env_vars
-    lower(var.value) == "true"
+is_debug_enabled(var) if {
+	var.name in _github_actions_debug_env_vars
+	lower(var.value) == "true"
 }
 
 results contains poutine.finding(rule, pkg.purl, {
@@ -55,32 +55,34 @@ results contains poutine.finding(rule, pkg.purl, {
 }) if {
 	pkg := input.packages[_]
 	workflow := pkg.github_actions_workflows[_]
-    var := workflow.env[_]
-    is_debug_enabled(var)
+	var := workflow.env[_]
+	is_debug_enabled(var)
 }
 
 results contains poutine.finding(rule, pkg.purl, {
 	"path": workflow.path,
 	"job": job.id,
 	"details": var.name,
+	"line": job.lines.start,
 }) if {
 	pkg := input.packages[_]
-    workflow := pkg.github_actions_workflows[_]
-    job := workflow.jobs[_]
-    var := job.env[_]
-    is_debug_enabled(var)
+	workflow := pkg.github_actions_workflows[_]
+	job := workflow.jobs[_]
+	var := job.env[_]
+	is_debug_enabled(var)
 }
 
 results contains poutine.finding(rule, pkg.purl, {
 	"path": workflow.path,
 	"job": job.id,
-	"step": step.id,
+	"step": step_id,
 	"details": var.name,
+	"line": step.lines.start,
 }) if {
 	pkg := input.packages[_]
-    workflow := pkg.github_actions_workflows[_]
-    job := workflow.jobs[_]
-    step := job.steps[_]
-    var := step.env[_]
-    is_debug_enabled(var)
+	workflow := pkg.github_actions_workflows[_]
+	job := workflow.jobs[_]
+	step := job.steps[step_id]
+	var := step.env[_]
+	is_debug_enabled(var)
 }

--- a/scanner/inventory_test.go
+++ b/scanner/inventory_test.go
@@ -99,8 +99,7 @@ func TestFindings(t *testing.T) {
 			Meta: opa.FindingMeta{
 				Job:     "build",
 				Path:    ".github/workflows/debug_enabled_valid.yml",
-				Step:    "0",
-				Line:    12,
+				Line:    9,
 				Details: "ACTIONS_STEP_DEBUG",
 			},
 		},
@@ -111,7 +110,7 @@ func TestFindings(t *testing.T) {
 				Job:     "build",
 				Path:    ".github/workflows/debug_enabled_valid.yml",
 				Step:    "0",
-				Line:    12,
+				Line:    14,
 				Details: "ACTIONS_STEP_DEBUG",
 			},
 		},

--- a/scanner/inventory_test.go
+++ b/scanner/inventory_test.go
@@ -99,7 +99,19 @@ func TestFindings(t *testing.T) {
 			Meta: opa.FindingMeta{
 				Job:     "build",
 				Path:    ".github/workflows/debug_enabled_valid.yml",
-				Step:    "1",
+				Step:    "0",
+				Line:    12,
+				Details: "ACTIONS_STEP_DEBUG",
+			},
+		},
+		{
+			RuleId: "debug_enabled",
+			Purl:   purl,
+			Meta: opa.FindingMeta{
+				Job:     "build",
+				Path:    ".github/workflows/debug_enabled_valid.yml",
+				Step:    "0",
+				Line:    12,
 				Details: "ACTIONS_STEP_DEBUG",
 			},
 		},

--- a/scanner/testdata/.github/workflows/debug_enabled_valid.yml
+++ b/scanner/testdata/.github/workflows/debug_enabled_valid.yml
@@ -8,8 +8,10 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_STEP_DEBUG: true
     steps:
-      - id: 1
+      - id: one
         env:
           ACTIONS_STEP_DEBUG: true
         run: echo Hello


### PR DESCRIPTION
In the `debug_enabled` rule:
- For GitHub Actions, report line numbers of the step or job that enables debugging. 
- Fix the `step` metadata value. It must be the step's index since the id is not always defined.

in analyze_org, log errors instead of cancelling the entire analysis of the org (see https://github.com/boostsecurityio/poutine/pull/102). Because of the wrong step reported in the `debug_enabled` rule, an org that had debugging enabled on a single workflow step could not be analyzed at all.  

Make it so `FindingMeta` parsing error are logged instead. Currently, if a finding with metadata that cannot be parse would crash the org's analysis with the following error:
```
12:55PM | ERROR | error="failed to analyze repo statusburger/actions: json: invalid number literal, trying to unmarshal \"\\\"\\\"\" into Number"
```

Now it logs the error and the metadata it tried to parse:
```
12:55PM | ERROR | failed to unmarshal FindingMeta error="json: invalid number literal, trying to unmarshal \"\\\"\\\"\" into Number" meta={"details":"ACTIONS_STEP_DEBUG","job":"build","line":21,"path":".github/workflows/debug.yml","step":""}
```
