### PR TITLE
Trim whitespace from Git errors

### DIFF
--- a/providers/gitops/gitops.go
+++ b/providers/gitops/gitops.go
@@ -44,7 +44,7 @@ func (g *ExecGitCommand) Run(ctx context.Context, cmd string, args []string, dir
 	stdout, err := command.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("command `%s` returned an error: %w stderr: %s", command.String(), err, string(exitErr.Stderr))
+			return nil, fmt.Errorf("command `%s` returned an error: %w stderr: %s", command.String(), err, string(bytes.TrimSpace(exitErr.Stderr)))
 		}
 		return nil, fmt.Errorf("error running command: %w", err)
 	}


### PR DESCRIPTION
This is a small cosmetic change to trim whitespace from Git command's Stderr output.

```
ERROR | failed to clone repo error="failed to clone repo: command `/usr/bin/git fetch --quiet --no-tags --depth 1 --filter=blob:none origin HEAD` returned an error: exit status 128 stderr: fatal: couldn't find remote ref HEAD\n" 
```