### PR TITLE
Only print rules with results

### DIFF
--- a/formatters/pretty/pretty.go
+++ b/formatters/pretty/pretty.go
@@ -3,10 +3,11 @@ package pretty
 import (
 	"context"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"io"
 	"os"
 	"sort"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/boostsecurityio/poutine/models"
 	"github.com/boostsecurityio/poutine/opa"
@@ -45,6 +46,11 @@ func printFindingsPerRule(out io.Writer, results map[string][]opa.Finding, rules
 	sort.Strings(sortedRuleIDs)
 
 	for _, ruleId := range sortedRuleIDs {
+		// Skip rules with no findings.
+		if len(results[ruleId]) == 0 {
+			continue
+		}
+
 		table := tablewriter.NewWriter(out)
 		table.SetAutoMergeCells(true)
 		table.SetHeader([]string{"Repository", "Details", "URL"})
@@ -95,11 +101,7 @@ func printFindingsPerRule(out io.Writer, results map[string][]opa.Finding, rules
 			table.Append([]string{})
 		}
 
-		if len(results[ruleId]) == 0 {
-			fmt.Fprint(out, "\nNo findings for this repository\n")
-		} else {
-			table.Render()
-		}
+		table.Render()
 		fmt.Fprint(out, "\n")
 	}
 }


### PR DESCRIPTION
This is a proposed change to improve the clarity of output. 

This fixes #99. (Need to write that for GitHub to link the issue.)

## Example

**Before**
```
Analyzing repositories  59% |███████████████████████                 | (22/37) [12s:6s]
Rule: CI Runner Debug Enabled
Severity: note
Description: The workflow is configured to increase the verbosity of the runner.
This can potentially expose sensitive information.
Documentation: https://boostsecurityio.github.io/poutine/rules/debug_enabled


No findings for this repository

Rule: Default permissions used on risky events
Severity: warning
Description: The workflow and some of its jobs do not explicitely define permissions
and the workflow triggers on events that are typically used to run builds from forks.
Because no permissions is set, the workflow inherits the default permissions
configured on the repository or the organization.
Documentation: https://boostsecurityio.github.io/poutine/rules/default_permissions_on_risky_events


No findings for this repository

Rule: Github Action from Unverified Creator used
Severity: note
Description: Usage of the following GitHub Actions repositories was detected in workflows
or composite actions, but their owner is not a verified creator.
Documentation: https://boostsecurityio.github.io/poutine/rules/github_action_from_unverified_creator_used

+-------------------------------+-------------------+--------------------------------------------------+
|          REPOSITORY           |      DETAILS      |                       URL                        |
+-------------------------------+-------------------+--------------------------------------------------+
| buildpulse/buildpulse-action  | Used in 1 repo(s) | https://github.com/buildpulse/buildpulse-action  |
|                               |                   |                                                  |
| mikepenz/action-junit-report  | Used in 1 repo(s) | https://github.com/mikepenz/action-junit-report  |
|                               |                   |                                                  |
| golangci/golangci-lint-action | Used in 3 repo(s) | https://github.com/golangci/golangci-lint-action |
|                               |                   |                                                  |
+-------------------------------+-------------------+--------------------------------------------------+

Rule: If condition always evaluates to true
Severity: error
Description: GitHub Actions expressions used in if condition of jobs or steps
must not contain extra characters or spaces.
Otherwise, the condition is always true.
Documentation: https://boostsecurityio.github.io/poutine/rules/if_always_true


No findings for this repository

Rule: Injection with Arbitrary External Contributor Input
Severity: warning
Description: The pipeline contains an injection into bash or JavaScript with an expression
that can contain user input. Prefer placing the expression in an environment variable
instead of interpolating it directly into a script.
Documentation: https://boostsecurityio.github.io/poutine/rules/injection


No findings for this repository

Rule: Workflow job exposes all secrets
Severity: warning
Description: The GitHub Actions Runner attempts to keep in memory only the secrets
that are necessary to execute a workflow job.
If a job converts the secrets object to JSON or accesses it using an expression,
all secrets will be retained in memory for the duration of the job.
Documentation: https://boostsecurityio.github.io/poutine/rules/job_all_secrets


No findings for this repository

Rule: Build Component with a Known Vulnerability used
Severity: warning
Description: The workflow or action depends on a GitHub Action with known vulnerabilities.
Documentation: https://boostsecurityio.github.io/poutine/rules/known_vulnerability_in_build_component


No findings for this repository

Rule: Build Platform with a Known Vulnerability used
Severity: warning
Description: The build or SCM provider used has a known vulnerability.
Documentation: https://boostsecurityio.github.io/poutine/rules/known_vulnerability_in_build_platform


No findings for this repository

Rule: Pull Request Runs on Self-Hosted GitHub Actions Runner
Severity: warning
Description: This job runs on a self-hosted GitHub Actions runner in a workflow
that is triggered by a pull request event.
Documentation: https://boostsecurityio.github.io/poutine/rules/pr_runs_on_self_hosted


No findings for this repository

Rule: Unpinnable CI component used
Severity: note
Description: Pinning this GitHub Action is likely ineffective
as it depends on other mutable supply chain components.
Documentation: https://boostsecurityio.github.io/poutine/rules/unpinnable_action


No findings for this repository

Rule: Arbitrary Code Execution from Untrusted Code Changes
Severity: error
Description: The workflow appears to checkout untrusted code from a fork
and uses a command that is known to allow code execution.
Documentation: https://boostsecurityio.github.io/poutine/rules/untrusted_checkout_exec


No findings for this repository


Summary of findings:
+--------------------------------------------+--------------------------------------------------------+----------+--------+
|                  RULE ID                   |                       RULE NAME                        | FAILURES | STATUS |
+--------------------------------------------+--------------------------------------------------------+----------+--------+
| debug_enabled                              | CI Runner Debug Enabled                                |        0 | Passed |
| default_permissions_on_risky_events        | Default permissions used on risky events               |        0 | Passed |
| github_action_from_unverified_creator_used | Github Action from Unverified Creator used             |        3 | Failed |
| if_always_true                             | If condition always evaluates to true                  |        0 | Passed |
| injection                                  | Injection with Arbitrary External Contributor Input    |        0 | Passed |
| job_all_secrets                            | Workflow job exposes all secrets                       |        0 | Passed |
| known_vulnerability_in_build_component     | Build Component with a Known Vulnerability used        |        0 | Passed |
| known_vulnerability_in_build_platform      | Build Platform with a Known Vulnerability used         |        0 | Passed |
| pr_runs_on_self_hosted                     | Pull Request Runs on Self-Hosted GitHub Actions Runner |        0 | Passed |
| unpinnable_action                          | Unpinnable CI component used                           |        0 | Passed |
| untrusted_checkout_exec                    | Arbitrary Code Execution from Untrusted Code Changes   |        0 | Passed |
+--------------------------------------------+--------------------------------------------------------+----------+--------+
```

**After**
```
Analyzing repositories  59% |███████████████████████                 | (22/37) [11s:6s]
Rule: Github Action from Unverified Creator used
Severity: note
Description: Usage of the following GitHub Actions repositories was detected in workflows
or composite actions, but their owner is not a verified creator.
Documentation: https://boostsecurityio.github.io/poutine/rules/github_action_from_unverified_creator_used

+-------------------------------+-------------------+--------------------------------------------------+
|          REPOSITORY           |      DETAILS      |                       URL                        |
+-------------------------------+-------------------+--------------------------------------------------+
| buildpulse/buildpulse-action  | Used in 1 repo(s) | https://github.com/buildpulse/buildpulse-action  |
|                               |                   |                                                  |
| mikepenz/action-junit-report  | Used in 1 repo(s) | https://github.com/mikepenz/action-junit-report  |
|                               |                   |                                                  |
| golangci/golangci-lint-action | Used in 3 repo(s) | https://github.com/golangci/golangci-lint-action |
|                               |                   |                                                  |
+-------------------------------+-------------------+--------------------------------------------------+


Summary of findings:
+--------------------------------------------+--------------------------------------------------------+----------+--------+
|                  RULE ID                   |                       RULE NAME                        | FAILURES | STATUS |
+--------------------------------------------+--------------------------------------------------------+----------+--------+
| debug_enabled                              | CI Runner Debug Enabled                                |        0 | Passed |
| default_permissions_on_risky_events        | Default permissions used on risky events               |        0 | Passed |
| github_action_from_unverified_creator_used | Github Action from Unverified Creator used             |        3 | Failed |
| if_always_true                             | If condition always evaluates to true                  |        0 | Passed |
| injection                                  | Injection with Arbitrary External Contributor Input    |        0 | Passed |
| job_all_secrets                            | Workflow job exposes all secrets                       |        0 | Passed |
| known_vulnerability_in_build_component     | Build Component with a Known Vulnerability used        |        0 | Passed |
| known_vulnerability_in_build_platform      | Build Platform with a Known Vulnerability used         |        0 | Passed |
| pr_runs_on_self_hosted                     | Pull Request Runs on Self-Hosted GitHub Actions Runner |        0 | Passed |
| unpinnable_action                          | Unpinnable CI component used                           |        0 | Passed |
| untrusted_checkout_exec                    | Arbitrary Code Execution from Untrusted Code Changes   |        0 | Passed |
+--------------------------------------------+--------------------------------------------------------+----------+--------+
```