### PR TITLE
Update README.md to refer to Homebrew core formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ To install `poutine`, download the latest release from the [releases page](https
 
 #### Homebrew
 ``` bash
-brew install boostsecurityio/tap/poutine
+[~] brew verify poutine
+==> poutine--0.10.1.sonoma.bottle.tar.gz has a valid attestation
+
+[~] brew install poutine
+🍺  /usr/local/Cellar/poutine/0.10.1: 9 files, 23.9MB
 ```
 
 #### Docker

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ To install `poutine`, download the latest release from the [releases page](https
 brew install poutine
 ```
 
+If you've used early versions of poutine through `brew`, you should remove the legacy tap, then you can install from the new official Homebrew Core
+```bash
+brew untap boostsecurityio/tap/poutine
+```
+
 #### Docker
 ``` bash
 docker run -e GH_TOKEN ghcr.io/boostsecurityio/poutine:latest

--- a/README.md
+++ b/README.md
@@ -36,11 +36,7 @@ To install `poutine`, download the latest release from the [releases page](https
 
 #### Homebrew
 ``` bash
-[~] brew verify poutine
-==> poutine--0.10.1.sonoma.bottle.tar.gz has a valid attestation
-
-[~] brew install poutine
-🍺  /usr/local/Cellar/poutine/0.10.1: 9 files, 23.9MB
+brew install poutine
 ```
 
 #### Docker


### PR DESCRIPTION
We've published to Homebrew Core now.

We will keep our local tap for now so that we can test both, but probably eventually drop the local tap.

Close #94 