### PR TITLE
docs: cleanup up tap reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,6 @@ To install `poutine`, download the latest release from the [releases page](https
 brew install poutine
 ```
 
-If you've used early versions of poutine through `brew`, you should remove the legacy tap, then you can install from the new official Homebrew Core
-```bash
-brew untap boostsecurityio/tap/poutine
-```
-
 #### Docker
 ``` bash
 docker run -e GH_TOKEN ghcr.io/boostsecurityio/poutine:latest


### PR DESCRIPTION
the tap migration would be handled by https://github.com/boostsecurityio/homebrew-tap/pull/1