### PR TITLE
fix: remove 2nd Rego compilation in json format, custom formats and validation

### DIFF
--- a/cmd/analyzeLocal.go
+++ b/cmd/analyzeLocal.go
@@ -20,7 +20,12 @@ Example: poutine analyze_local /path/to/repo`,
 		ctx := cmd.Context()
 		repoPath := args[0]
 
-		formatter := GetFormatter()
+		opaClient, err := newOpa(ctx)
+		if err != nil {
+			return err
+		}
+
+		formatter := GetFormatter(opaClient)
 
 		localScmClient, err := local.NewGitSCMClient(ctx, repoPath, nil)
 		if err != nil {
@@ -29,7 +34,7 @@ Example: poutine analyze_local /path/to/repo`,
 
 		localGitClient := gitops.NewLocalGitClient(nil)
 
-		analyzer := analyze.NewAnalyzer(localScmClient, localGitClient, formatter, config)
+		analyzer := analyze.NewAnalyzer(localScmClient, localGitClient, formatter, config, opaClient)
 
 		err = analyzer.AnalyzeLocalRepo(ctx, repoPath)
 		if err != nil {

--- a/opa/rego/poutine/queries/format.rego
+++ b/opa/rego/poutine/queries/format.rego
@@ -1,0 +1,24 @@
+package poutine.queries.format
+
+import rego.v1
+
+default output := ""
+
+output = data.poutine.format[input.format].result
+
+formats contains format if data.poutine.format[format]
+
+formats contains input.builtin_formats[_]
+
+errors contains error if {
+	not input.format in formats
+	error := sprintf("format %s not found in the available formats: %s", [
+		input.format,
+		concat(", ", formats),
+	])
+}
+
+result = {
+	"output": output,
+	"error": concat(", ", errors),
+}

--- a/providers/github/client.go
+++ b/providers/github/client.go
@@ -254,7 +254,7 @@ func (c *Client) GetOrgRepos(ctx context.Context, org string) <-chan analyze.Rep
 		for {
 			var query struct {
 				RepositoryOwner struct {
-					Login string
+					Login        string
 					Repositories struct {
 						TotalCount int
 						Nodes      []GithubRepository


### PR DESCRIPTION
When using the JSON format, another OPA instance was created different than the one used to analyze the packages. This new OPA instance is not configured so the included Rego from the configuration cannot be used to define formats.

`analyzer.NewAnalyzer` now requires an OPA instance as argument.

This PR also modifies the behavior when running poutine with an unknown format. It used to silently fall back to the pretty format. It will now error out and list the available formats:
```
$ go run . analyze_local scanner/testdata -f asdf
Error: failed to analyze repoPath scanner/testdata: format asdf not found in the available formats: json, pretty, sarif
```

