### PR TITLE
opa: expose `json.marshal_with_options`

### DIFF
--- a/opa/capabilities.json
+++ b/opa/capabilities.json
@@ -2162,6 +2162,51 @@
       }
     },
     {
+      "name": "json.marshal_with_options",
+      "decl": {
+        "args": [
+          {
+            "type": "any"
+          },
+          {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "static": [
+              {
+                "key": "indent",
+                "value": {
+                  "type": "string"
+                }
+              },
+              {
+                "key": "prefix",
+                "value": {
+                  "type": "string"
+                }
+              },
+              {
+                "key": "pretty",
+                "value": {
+                  "type": "boolean"
+                }
+              }
+            ],
+            "type": "object"
+          }
+        ],
+        "result": {
+          "type": "string"
+        },
+        "type": "function"
+      }
+    },
+    {
       "name": "json.match_schema",
       "decl": {
         "args": [


### PR DESCRIPTION
Support for this capability was added in https://github.com/boostsecurityio/poutine/pull/48 but not exposed.