### PR TITLE
feat: add `--quiet` option

### DIFF
--- a/analyze/analyze.go
+++ b/analyze/analyze.go
@@ -92,12 +92,7 @@ func (a *Analyzer) AnalyzeOrg(ctx context.Context, org string, numberOfGoroutine
 	inventory := scanner.NewInventory(opaClient, pkgsupplyClient, provider, providerVersion)
 
 	log.Debug().Msgf("Starting repository analysis for organization: %s on %s", org, provider)
-	bar := progressbar.NewOptions(
-		0,
-		progressbar.OptionSetDescription("Analyzing repositories"),
-		progressbar.OptionShowCount(),
-		progressbar.OptionSetWriter(os.Stderr),
-	)
+	bar := a.progressBar(0, "Analyzing repositories")
 
 	var wg sync.WaitGroup
 	errChan := make(chan error, 1)
@@ -164,6 +159,8 @@ func (a *Analyzer) AnalyzeOrg(ctx context.Context, org string, numberOfGoroutine
 		}
 	}
 
+	_ = bar.Finish()
+
 	return a.finalizeAnalysis(ctx, inventory)
 }
 
@@ -194,18 +191,17 @@ func (a *Analyzer) AnalyzeRepo(ctx context.Context, repoString string, ref strin
 	inventory := scanner.NewInventory(opaClient, pkgsupplyClient, provider, providerVersion)
 
 	log.Debug().Msgf("Starting repository analysis for: %s/%s on %s", org, repoName, provider)
-	bar := progressbar.NewOptions(
-		1,
-		progressbar.OptionSetDescription("Analyzing repository"),
-		progressbar.OptionShowCount(),
-		progressbar.OptionSetWriter(os.Stderr),
-	)
+	bar := a.progressBar(2, "Cloning repository")
+	_ = bar.RenderBlank()
 
 	tempDir, err := a.cloneRepoToTemp(ctx, repo.BuildGitURL(a.ScmClient.GetProviderBaseURL()), a.ScmClient.GetToken(), ref)
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(tempDir)
+
+	bar.Describe("Analyzing repository")
+	_ = bar.Add(1)
 
 	pkg, err := a.generatePackageInsights(ctx, tempDir, repo, ref)
 	if err != nil {
@@ -216,9 +212,8 @@ func (a *Analyzer) AnalyzeRepo(ctx context.Context, repoString string, ref strin
 	if err != nil {
 		return err
 	}
-	_ = bar.Add(1)
+	_ = bar.Finish()
 
-	fmt.Print("\n\n")
 	return a.finalizeAnalysis(ctx, inventory)
 }
 
@@ -245,16 +240,9 @@ func (a *Analyzer) AnalyzeLocalRepo(ctx context.Context, repoPath string) error 
 		return err
 	}
 	pkgsupplyClient := pkgsupply.NewStaticClient()
-
 	inventory := scanner.NewInventory(opaClient, pkgsupplyClient, provider, providerVersion)
 
 	log.Debug().Msgf("Starting repository analysis for: %s/%s on %s", org, repoName, provider)
-	bar := progressbar.NewOptions(
-		1,
-		progressbar.OptionSetDescription("Analyzing repository"),
-		progressbar.OptionShowCount(),
-		progressbar.OptionSetWriter(os.Stderr),
-	)
 
 	pkg, err := a.generatePackageInsights(ctx, repoPath, repo, "")
 	if err != nil {
@@ -265,9 +253,7 @@ func (a *Analyzer) AnalyzeLocalRepo(ctx context.Context, repoPath string) error 
 	if err != nil {
 		return err
 	}
-	_ = bar.Add(1)
 
-	fmt.Print("\n\n")
 	return a.finalizeAnalysis(ctx, inventory)
 }
 
@@ -347,4 +333,19 @@ func (a *Analyzer) newOpa(ctx context.Context) (*opa.Opa, error) {
 	_ = opaClient.WithConfig(ctx, a.Config)
 
 	return opaClient, nil
+}
+
+func (a *Analyzer) progressBar(max int64, description string) *progressbar.ProgressBar {
+	if a.Config.Quiet {
+		return progressbar.DefaultSilent(max, description)
+	} else {
+		return progressbar.NewOptions64(
+			max,
+			progressbar.OptionSetDescription(description),
+			progressbar.OptionShowCount(),
+			progressbar.OptionSetWriter(os.Stderr),
+			progressbar.OptionClearOnFinish(),
+		)
+
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ var Format string
 var Verbose bool
 var ScmProvider string
 var ScmBaseURL scm.ScmBaseDomain
+var Quiet bool
 var (
 	Version string
 	Commit  string
@@ -59,7 +60,6 @@ By BoostSecurity.io - https://github.com/boostsecurityio/poutine `,
 			return strings.ToUpper(fmt.Sprintf("| %-6s|", i))
 		}
 		log.Logger = log.Output(output)
-
 	},
 }
 
@@ -111,6 +111,9 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "Enable verbose logging")
 	rootCmd.PersistentFlags().StringVarP(&ScmProvider, "scm", "s", "github", "SCM platform (github, gitlab)")
 	rootCmd.PersistentFlags().VarP(&ScmBaseURL, "scm-base-url", "b", "Base URI of the self-hosted SCM instance (optional)")
+	rootCmd.PersistentFlags().BoolVarP(&Quiet, "quiet", "q", false, "Disable progress output")
+
+	viper.BindPFlag("quiet", rootCmd.PersistentFlags().Lookup("quiet"))
 }
 
 func initConfig() {

--- a/models/config.go
+++ b/models/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Skip        []ConfigSkip    `json:"skip"`
 	Include     []ConfigInclude `json:"include"`
 	IgnoreForks bool            `json:"ignore_forks,omitempty"`
+	Quiet       bool            `json:"quiet,omitempty"`
 }
 
 func DefaultConfig() *Config {


### PR DESCRIPTION
- Fix #123
- Changed the `anlayze_repo` progress bar to provide progress on the git clone step and the analysis step. On big repos this helps showing that we're waiting for the git clone.
- Remove fmt.Println in analyze
- Enable auto clearing the progress bar when it's finished.