### PR TITLE
chore: add dockerfile, upgrade git image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.github
+.git
+docs/themes
+Dockerfile
+.dockerignore
+.env
+/*.md
+/poutine

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
 
 kos:
   - repository: ghcr.io/boostsecurityio/poutine
-    base_image: 'cgr.dev/chainguard/git:latest@sha256:f06036ea97419c784339638cf4a21b52d39df8dfd8aa0e0e73307fc1082c6043'
+    base_image: 'cgr.dev/chainguard/git:latest@sha256:06119871a608d163eac2daddd0745582e457a29ee8402bd351c13f294ede30e1'
     tags:
       - '{{.Version}}'
       - latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+ARG GIT=cgr.dev/chainguard/git:latest@sha256:06119871a608d163eac2daddd0745582e457a29ee8402bd351c13f294ede30e1
+ARG GORELEASER=ghcr.io/goreleaser/goreleaser:v2.0.1@sha256:c1d6c5a07be6d0f7472461e2ec578beaa4a51c12bb03a8e34d3e73730b4aa32a
+
+FROM ${GORELEASER} as goreleaser
+WORKDIR /app
+COPY . .
+RUN goreleaser build --snapshot --single-target
+RUN mv dist/*/poutine /usr/bin/poutine
+
+FROM ${GIT} as base
+WORKDIR /src
+RUN git config --global --add safe.directory /src
+
+FROM base as poutine
+COPY --from=goreleaser /usr/bin/poutine /usr/bin/poutine
+ENTRYPOINT ["/usr/bin/poutine"]


### PR DESCRIPTION
- add a dockerfile to more easily build a container with poutine without having goreleaser or ko
  - the `base` target could be used in the future as a base image to address https://github.com/boostsecurityio/poutine/issues/78
- upgrade the base image to patch busybox CVEs