### PR TITLE
add gitlab CVE-2024-5655

### DIFF
--- a/opa/rego/external/build_platform.rego
+++ b/opa/rego/external/build_platform.rego
@@ -1,20 +1,40 @@
 package external.build_platform
 
 advisories = {
-	"gitlab": {"CVE-2024-2651": {
-		"osv_id": "CVE-2024-2651",
-		"published": "2024-05-14T00:00:00Z",
-		"aliases": [],
-		"summary": "It was possible for an attacker to cause a denial of service using maliciously crafted markdown content.",
-		"severity": [{
-			"type": "CVSS_V3",
-			"score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
-		}],
-		"cwe_ids": ["CWE-400"],
-		"vulnerable_versions": [],
-		"vulnerable_version_ranges": [">=0,<16.9.7"],
-		"vulnerable_commit_shas": [],
-	}},
+	"gitlab": {
+		"CVE-2024-5655": {
+			"osv_id": "CVE-2024-5655",
+			"published": "2024-06-26T00:00:00Z",
+			"aliases": [],
+			"summary": "It was possible for an attacker to trigger a pipeline as another user under certain circumstances.",
+			"severity": [{
+				"type": "CVSS_V3",
+				"score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:N",
+			}],
+			"cwe_ids": ["CWE-284"],
+			"vulnerable_versions": [],
+			"vulnerable_version_ranges": [
+				">=15.8.0,<16.11.5",
+				">=17.0.0,<17.0.3",
+				">=17.1.0,<17.1.1",
+			],
+			"vulnerable_commit_shas": [],
+		},
+		"CVE-2024-2651": {
+			"osv_id": "CVE-2024-2651",
+			"published": "2024-05-14T00:00:00Z",
+			"aliases": [],
+			"summary": "It was possible for an attacker to cause a denial of service using maliciously crafted markdown content.",
+			"severity": [{
+				"type": "CVSS_V3",
+				"score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+			}],
+			"cwe_ids": ["CWE-400"],
+			"vulnerable_versions": [],
+			"vulnerable_version_ranges": [">=0,<16.9.7"],
+			"vulnerable_commit_shas": [],
+		},
+	},
 	"github": {"CVE-2024-4985": {
 		"osv_id": "CVE-2024-4985",
 		"published": "2024-05-20T00:00:00Z",

--- a/opa/rego/rules/known_vulnerability_in_build_platform.rego
+++ b/opa/rego/rules/known_vulnerability_in_build_platform.rego
@@ -15,18 +15,11 @@ import rego.v1
 
 rule := poutine.rule(rego.metadata.chain())
 
-provider_advisory(provider, provider_version) = advisory if {
-	version := provider_version
-	advisory := advisories[provider][osv_id]
-
-	regex.match("^[0-9]+(\\.[0-9]+)*?$", version)
-
-	semver.constraint_check(advisory.vulnerable_version_ranges[_], version)
-}
-
 results contains poutine.finding(rule, input.provider, {
 	"osv_id": advisory.osv_id,
 	"details": sprintf("Provider: %s", [input.provider]),
 }) if {
-	advisory := provider_advisory(input.provider, input.version)
+	advisory := advisories[input.provider][osv_id]
+	regex.match("^[0-9]+(\\.[0-9]+)*?$", input.version)
+	semver.constraint_check(advisory.vulnerable_version_ranges[_], input.version)
 }

--- a/scanner/inventory_test.go
+++ b/scanner/inventory_test.go
@@ -254,6 +254,14 @@ func TestFindings(t *testing.T) {
 			},
 		},
 		{
+			RuleId: "known_vulnerability_in_build_platform",
+			Purl:   "gitlab",
+			Meta: opa.FindingMeta{
+				OsvId:   "CVE-2024-5655",
+				Details: "Provider: gitlab",
+			},
+		},
+		{
 			RuleId: "injection",
 			Purl:   purl,
 			Meta: opa.FindingMeta{


### PR DESCRIPTION
https://about.gitlab.com/releases/2024/06/26/patch-release-gitlab-17-1-1-released/#run-pipelines-as-any-user


adding this CVE uncovered the bug that `data.rules.known_vulnerability_in_build_platform.provider_advisory` crashes opa's evaluation when the SCM instance is affected by multiple advisories. 
