### PR TITLE
feat: rules configuration for `pr_runs_on_self_hosted`

### DIFF
--- a/.poutine.sample.yml
+++ b/.poutine.sample.yml
@@ -2,6 +2,15 @@
 # default: false
 ignoreForks: true
 
+# Set rule configuration options
+rulesConfig:
+  pr_runs_on_self_hosted:
+    allowed_runners:
+    - self-hosted
+    - label:gpu
+    - group:prdeploy
+
+
 # Skip findings if any rules in this list matches the finding's properties.
 # Each rule can have the following keys: job, level, osv_id, path, purl, rule.
 # The value of each key is a string or a list of strings.

--- a/models/config.go
+++ b/models/config.go
@@ -14,10 +14,11 @@ type ConfigInclude struct {
 }
 
 type Config struct {
-	Skip        []ConfigSkip    `json:"skip"`
-	Include     []ConfigInclude `json:"include"`
-	IgnoreForks bool            `json:"ignore_forks,omitempty"`
-	Quiet       bool            `json:"quiet,omitempty"`
+	Skip        []ConfigSkip                      `json:"skip"`
+	Include     []ConfigInclude                   `json:"include"`
+	IgnoreForks bool                              `json:"ignore_forks"`
+	Quiet       bool                              `json:"quiet,omitempty"`
+	RulesConfig map[string]map[string]interface{} `json:"rules_config"`
 }
 
 func DefaultConfig() *Config {

--- a/opa/models.go
+++ b/opa/models.go
@@ -50,6 +50,13 @@ type Rule struct {
 		Ref         string `json:"ref"`
 		Description string `json:"description"`
 	} `json:"refs,omitempty"`
+	Config map[string]RuleConfig `json:"config,omitempty"`
+}
+
+type RuleConfig struct {
+	Default     interface{} `json:"default"`
+	Description string      `json:"description"`
+	Value       interface{} `json:"value"`
 }
 
 func (m *FindingMeta) UnmarshalJSON(data []byte) error {

--- a/opa/rego/poutine.rego
+++ b/opa/rego/poutine.rego
@@ -8,6 +8,7 @@ rule(chain) = {
 	"description": meta.description,
 	"level": meta.custom.level,
 	"refs": object.get(meta, "related_resources", []),
+	"config": _rule_config(rule_id, meta),
 } if {
 	module := chain[1]
 	module.path[0] == "rules"
@@ -27,4 +28,15 @@ finding(rule, pkg_purl, meta) = {
 	"rule_id": rule.id,
 	"purl": pkg_purl,
 	"meta": meta,
+}
+
+_rule_config(rule_id, meta) = object.union(rule_config, config_values) if {
+	rule_config := {key: value |
+		param := meta.custom.config[key]
+		value := object.union({"value": object.get(param, "default", null)}, param)
+	}
+	config_values := {key: {"value": value} |
+		param := rule_config[k]
+		value := data.config.rules_config[rule_id][key]
+	}
 }

--- a/opa/rego/poutine/utils.rego
+++ b/opa/rego/poutine/utils.rego
@@ -68,3 +68,9 @@ workflow_run_parents(pkg, workflow) = parents if {
 		glob.match(parent_names[_], ["/"], parent.name)
 	}
 }
+
+to_set(xs) = xs if {
+	is_set(xs)
+} else := {v | v := xs[_]} if {
+	is_array(xs)
+} else := {xs}

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -24,6 +24,7 @@ func TestGithubWorkflows(t *testing.T) {
 		".github/workflows/secrets.yaml",
 		".github/workflows/workflow_run_valid.yml",
 		".github/workflows/workflow_run_reusable.yml",
+		".github/workflows/allowed_pr_runner.yml",
 	})
 }
 

--- a/scanner/testdata/.github/workflows/allowed_pr_runner.yml
+++ b/scanner/testdata/.github/workflows/allowed_pr_runner.yml
@@ -1,0 +1,21 @@
+name: allowed_pr_runner.yml
+on:
+  pull_request:
+
+jobs:
+  hosted:
+    runs-on: [macos-latest, ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v4
+
+  group:
+    runs-on:
+      group: prdeploy
+    steps:
+    - uses: actions/checkout@v4
+
+  labels:
+    runs-on:
+      labels: linux
+    steps:
+    - uses: actions/checkout@v4


### PR DESCRIPTION
- extend the rule metadata schema to allow declaring rule-specific configuration options
- in the config file, rule configurations are placed in `rulesConfig`
- add the `allowed_runners` configuration option for `pr_runs_on_self_hosted` to fix #155
