### PR TITLE
feat: Azure Pipelines

### DIFF
--- a/models/azure_pipelines.go
+++ b/models/azure_pipelines.go
@@ -1,0 +1,129 @@
+package models
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v3"
+)
+
+// https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pipeline?view=azure-pipelines
+type AzurePipeline struct {
+	Path string `json:"path" yaml:"-"`
+
+	Stages []AzureStage `json:"stages"`
+	Pr     AzurePr      `json:"pr"`
+}
+
+func (o AzurePipeline) IsValid() bool {
+	return len(o.Stages) > 0 && len(o.Stages[0].Jobs) > 0
+}
+
+// https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/stages-stage?view=azure-pipelines
+type AzureStage struct {
+	Stage string     `json:"stage"`
+	Jobs  []AzureJob `json:"jobs"`
+}
+
+// https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/jobs-job?view=azure-pipelines
+type AzureJob struct {
+	Job   string      `json:"job"`
+	Steps []AzureStep `json:"steps"`
+}
+
+// https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps?view=azure-pipelines
+type AzureStep struct {
+	Task       string `json:"task,omitempty"`
+	Script     string `json:"script,omitempty"`
+	Powershell string `json:"powershell,omitempty"`
+	Pwsh       string `json:"pwsh,omitempty"`
+	Bash       string `json:"bash,omitempty"`
+	Checkout   string `json:"checkout,omitempty"`
+
+	Lines map[string]int `json:"lines" yaml:"-"`
+}
+
+// https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pr?view=azure-pipelines
+type AzurePr struct {
+	Disabled bool `json:"disabled" yaml:"-"`
+
+	Branches *AzureIncludeExclude `json:"branches"`
+	Paths    *AzureIncludeExclude `json:"paths"`
+	Tags     *AzureIncludeExclude `json:"tags"`
+	Drafts   bool                 `json:"drafts"`
+}
+
+type AzureIncludeExclude struct {
+	Include StringList `json:"include"`
+	Exclude StringList `json:"exclude"`
+}
+
+func (o *AzurePipeline) UnmarshalYAML(node *yaml.Node) error {
+	type pipeline AzurePipeline
+	var p pipeline
+	if err := node.Decode(&p); err != nil {
+		return err
+	}
+
+	if len(p.Stages) == 0 {
+		stage := AzureStage{}
+		if err := node.Decode(&stage); err != nil {
+			return err
+		}
+
+		if len(stage.Jobs) == 0 {
+			job := AzureJob{}
+			if err := node.Decode(&job); err != nil {
+				return err
+			}
+
+			stage.Jobs = append(stage.Jobs, job)
+		}
+
+		p.Stages = append(p.Stages, stage)
+	}
+
+	*o = AzurePipeline(p)
+	return nil
+}
+
+func (o *AzurePr) UnmarshalYAML(node *yaml.Node) error {
+	o.Drafts = true
+
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if node.Value == "none" {
+			o.Disabled = true
+			return nil
+		}
+		return fmt.Errorf("invalid scalar value for AzurePr: %s", node.Value)
+	case yaml.SequenceNode:
+		o.Branches = &AzureIncludeExclude{}
+		return node.Decode(&o.Branches.Include)
+	case yaml.MappingNode:
+		type pr AzurePr
+		return node.Decode((*pr)(o))
+	}
+
+	return nil
+}
+
+func (o *AzureStep) UnmarshalYAML(node *yaml.Node) error {
+	type step AzureStep
+	var s step
+	if err := node.Decode(&s); err != nil {
+		return err
+	}
+
+	if node.Kind == yaml.MappingNode {
+		s.Lines = map[string]int{"start": node.Line}
+		for i := 0; i < len(node.Content); i += 2 {
+			key := node.Content[i].Value
+			switch key {
+			case "task", "script", "powershell", "pwsh", "bash", "checkout":
+				s.Lines[key] = node.Content[i+1].Line
+			}
+		}
+	}
+
+	*o = AzureStep(s)
+	return nil
+}

--- a/models/azure_pipelines_test.go
+++ b/models/azure_pipelines_test.go
@@ -1,0 +1,145 @@
+package models
+
+import (
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+	"testing"
+)
+
+func TestAzurePipeline(t *testing.T) {
+	lines := map[string]int{"bash": 1, "start": 1}
+	cases := []struct {
+		input    string
+		expected AzurePipeline
+		error    bool
+	}{
+		{
+			input: `steps: [bash: asdf]`,
+			expected: AzurePipeline{
+				Stages: []AzureStage{
+					{
+						Jobs: []AzureJob{
+							{
+								Steps: []AzureStep{
+									{
+										Bash:  "asdf",
+										Lines: lines,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			input: `stages: [{stage: build, jobs: [{job: test, steps: [bash: asdf]}]}]`,
+			expected: AzurePipeline{
+				Stages: []AzureStage{
+					{
+						Stage: "build",
+						Jobs: []AzureJob{
+							{
+								Job: "test",
+								Steps: []AzureStep{
+									{
+										Bash:  "asdf",
+										Lines: lines,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			input: `jobs: [{job: test, steps: [bash: asdf]}]`,
+			expected: AzurePipeline{
+				Stages: []AzureStage{
+					{
+						Jobs: []AzureJob{
+							{
+								Job: "test",
+								Steps: []AzureStep{
+									{
+										Bash:  "asdf",
+										Lines: lines,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, c := range cases {
+		var result AzurePipeline
+		err := yaml.Unmarshal([]byte(c.input), &result)
+		if c.error {
+			assert.NotNil(t, err, i)
+		} else {
+			assert.Nil(t, err)
+			assert.Equal(t, c.expected, result, i)
+		}
+	}
+}
+
+func TestAzurePr(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected AzurePr
+		error    bool
+	}{
+		{
+			input: `asdf`,
+			error: true,
+		},
+		{
+			input: `none`,
+			expected: AzurePr{
+				Disabled: true,
+				Drafts:   true,
+			},
+		},
+		{
+			input: `[main, dev]`,
+			expected: AzurePr{
+				Branches: &AzureIncludeExclude{
+					Include: StringList{"main", "dev"},
+				},
+				Drafts: true,
+			},
+		},
+		{
+			input: `{branches: {include: [main, dev]}}`,
+			expected: AzurePr{
+				Branches: &AzureIncludeExclude{
+					Include: StringList{"main", "dev"},
+				},
+				Drafts: true,
+			},
+		},
+		{
+			input: `{drafts: false, branches: {include: [main, dev]}}`,
+			expected: AzurePr{
+				Branches: &AzureIncludeExclude{
+					Include: StringList{"main", "dev"},
+				},
+			},
+		},
+	}
+
+	for i, c := range cases {
+		var result AzurePr
+		err := yaml.Unmarshal([]byte(c.input), &result)
+		if c.error {
+			assert.NotNil(t, err, i)
+		} else {
+			assert.Nil(t, err)
+			assert.Equal(t, c.expected, result, i)
+		}
+	}
+}

--- a/models/package_insights.go
+++ b/models/package_insights.go
@@ -29,8 +29,8 @@ type PackageInsights struct {
 
 	GithubActionsWorkflows []GithubActionsWorkflow `json:"github_actions_workflows"`
 	GithubActionsMetadata  []GithubActionsMetadata `json:"github_actions_metadata"`
-
-	GitlabciConfigs []GitlabciConfig `json:"gitlabci_configs"`
+	GitlabciConfigs        []GitlabciConfig        `json:"gitlabci_configs"`
+	AzurePipelines         []AzurePipeline         `json:"azure_pipelines"`
 }
 
 func (p *PackageInsights) GetSourceGitRepoURI() string {

--- a/opa/rego/poutine/inventory/azure_pipelines.rego
+++ b/opa/rego/poutine/inventory/azure_pipelines.rego
@@ -1,0 +1,14 @@
+package poutine.inventory
+
+import rego.v1
+
+build_dependencies contains dep if {
+	pkg := input.packages[_]
+	pipeline := pkg.azure_pipelines[_]
+	stage := pipeline.stages[_]
+	job := stage.jobs[_]
+	step := job.steps[_]
+
+	not contains(step.task, "$")
+	dep := sprintf("pkg:azurepipelinestask/%s", [step.task])
+}

--- a/opa/rego/rules/unverified_script_exec.rego
+++ b/opa/rego/rules/unverified_script_exec.rego
@@ -73,3 +73,18 @@ _scripts[pkg.purl] contains {
 	script := job[attr][_]
 	details := _unverified_scripts(script.run)[_]
 }
+
+_scripts[pkg.purl] contains {
+	"path": pipeline.path,
+	"job": job.job,
+	"step": step_id,
+	"line": step.lines[attr],
+	"details": details,
+} if {
+	some attr in {"script", "powershell", "pwsh", "bash"}
+	pkg := input.packages[_]
+	pipeline := pkg.azure_pipelines[_]
+	job := pipeline.stages[_].jobs[_]
+	step := job.steps[step_id]
+	details := _unverified_scripts(step[attr])[_]
+}

--- a/scanner/inventory_test.go
+++ b/scanner/inventory_test.go
@@ -43,10 +43,12 @@ func TestPurls(t *testing.T) {
 		"pkg:docker/debian%3Avuln",
 		"pkg:githubactions/bridgecrewio/checkov-action@main",
 		"pkg:githubactions/org/repo@main#.github/workflows/Reusable.yml",
+		"pkg:azurepipelinestask/DownloadPipelineArtifact@2",
+		"pkg:azurepipelinestask/Cache@2",
 	}
 	assert.ElementsMatch(t, i.Purls(), purls)
 	assert.Equal(t, 1, len(i.Packages))
-	assert.Equal(t, 16, len(i.Packages[0].BuildDependencies))
+	assert.Equal(t, 18, len(i.Packages[0].BuildDependencies))
 	assert.Equal(t, 4, len(i.Packages[0].PackageDependencies))
 }
 
@@ -355,6 +357,27 @@ func TestFindings(t *testing.T) {
 				Job:     "build",
 				Step:    "13",
 				Details: "Command: curl https://raw.githubusercontent.com/org/repo/main/install.sh | bash",
+			},
+		},
+		{
+			RuleId: "unverified_script_exec",
+			Purl:   purl,
+			Meta: opa.FindingMeta{
+				Path:    "azure-pipelines-1.yml",
+				Line:    8,
+				Step:    "2",
+				Details: "Command: curl $(URL) | bash",
+			},
+		},
+		{
+			RuleId: "injection",
+			Purl:   purl,
+			Meta: opa.FindingMeta{
+				Path:    ".azure-pipelines.yml",
+				Line:    11,
+				Job:     "build",
+				Step:    "1",
+				Details: "Sources: Build.SourceBranch",
 			},
 		},
 	}

--- a/scanner/testdata/.azure-pipelines.yml
+++ b/scanner/testdata/.azure-pipelines.yml
@@ -1,0 +1,11 @@
+pr:
+  branches:
+    include:
+      - master
+
+# implicit stage
+jobs:
+- job: build
+  steps:
+  - task: Cache@2
+  - powershell: echo "$(Build.SourceBranch)"

--- a/scanner/testdata/azure-pipelines-1.yml
+++ b/scanner/testdata/azure-pipelines-1.yml
@@ -1,0 +1,9 @@
+pr: none
+
+# implicit stage, job
+steps:
+- task: DownloadPipelineArtifact@2
+- powershell: |
+    echo "Hello, pr!"
+- bash: |
+    curl $(URL) | bash


### PR DESCRIPTION
- Initial support to parse Azure Pipelines. 
  - Only the [pr](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pr?view=azure-pipelines) field and [steps](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps?view=azure-pipelines) are modeled.
  - Only a subset of files are considered as Azure Pipelines.
  - No support for expressions. 
- Add rules in `unverified_script_exec` & `injection`  to analyze Azure Pipelines.
- The tasks used in a pipeline are reported in the build inventory using the purl type `pkg:azurepipelinestask`