### PR TITLE
Fix CVE-2020-13283 matching

### DIFF
--- a/opa/rego/external/build_platform.rego
+++ b/opa/rego/external/build_platform.rego
@@ -937,7 +937,11 @@ advisories = {
 			}],
 			"cwe_ids": [""],
 			"vulnerable_versions": [],
-			"vulnerable_version_ranges": [">=10.8"],
+			"vulnerable_version_ranges": [
+				">=10.8, <13.0.12",
+				">=13.1, <13.1.6",
+				">=13.2, <13.2.3",
+			],
 			"vulnerable_commit_shas": [],
 		},
 		"CVE-2020-13284": {


### PR DESCRIPTION
The rule generated was too lax `>=10.8`

https://gitlab.com/gitlab-org/cves/-/blob/master/2020/CVE-2020-13283.json

I'll file a bug so that we update the CVE DB update to have fixups routines and/or use the Gitlab CVE assignement DB for Gitlab (https://gitlab.com/gitlab-org/cves/-/tree/master)