### PR TITLE
Fix finding URL not respecting `--scm-base-url`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/boostsecurityio/poutine/opa"
 	"github.com/boostsecurityio/poutine/providers/gitops"
 	"github.com/boostsecurityio/poutine/providers/scm"
+	"github.com/boostsecurityio/poutine/providers/scm/domain"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
@@ -26,7 +27,7 @@ import (
 var Format string
 var Verbose bool
 var ScmProvider string
-var ScmBaseURL scm.ScmBaseDomain
+var ScmBaseURL scm_domain.ScmBaseDomain
 var (
 	Version string
 	Commit  string

--- a/models/purl.go
+++ b/models/purl.go
@@ -2,8 +2,9 @@ package models
 
 import (
 	"fmt"
-	"github.com/package-url/packageurl-go"
 	"strings"
+
+	"github.com/package-url/packageurl-go"
 )
 
 type Purl struct {
@@ -45,11 +46,22 @@ func (p *Purl) FullName() string {
 
 func (p *Purl) Link() string {
 	repo := p.FullName()
+	qualifiers := p.Qualifiers.Map()
+	repoUrl := qualifiers["repository_url"]
+
 	if p.Type == "githubactions" || p.Type == "github" {
-		return fmt.Sprintf("https://github.com/%s", repo)
+		if repoUrl != "" {
+			return fmt.Sprintf("https://%s/%s", repoUrl, repo)
+		} else {
+			return fmt.Sprintf("https://github.com/%s", repo)
+		}
 	}
 	if p.Type == "gitlab" {
-		return fmt.Sprintf("https://gitlab.com/%s", repo)
+		if repoUrl != "" {
+			return fmt.Sprintf("https://%s/%s", repoUrl, repo)
+		} else {
+			return fmt.Sprintf("https://gitlab.com/%s", repo)
+		}
 	}
 	return ""
 }

--- a/models/purl_test.go
+++ b/models/purl_test.go
@@ -87,3 +87,44 @@ func TestPurlFromGithubActions(t *testing.T) {
 		}
 	}
 }
+
+func TestPurlLink(t *testing.T) {
+	cases := []struct {
+		name     string
+		purl     string
+		expected string
+	}{
+		// GitHub
+		{
+			name:     "github.com default",
+			purl:     "pkg:githubactions/actions/checkout@v4",
+			expected: "https://github.com/actions/checkout",
+		},
+		{
+			name:     "github custom base ",
+			purl:     "pkg:githubactions/actions/checkout@v4?repository_url=github.example.com",
+			expected: "https://github.example.com/actions/checkout",
+		},
+		// GitLab
+		{
+			name:     "gitlab.com default",
+			purl:     "pkg:gitlab/include/remote?download_url=https%3A%2F%2Fexample.com%2F.gitlab-ci.yml",
+			expected: "https://gitlab.com/include/remote",
+		},
+		{
+			name:     "gitlab custom base",
+			purl:     "pkg:gitlab/include/remote?download_url=https%3A%2F%2Fexample.com%2F.gitlab-ci.yml&repository_url=gitlab.example.com",
+			expected: "https://gitlab.example.com/include/remote",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p, err := NewPurl(c.purl)
+			assert.Nil(t, err)
+
+			link := p.Link()
+			assert.Equal(t, c.expected, link)
+		})
+	}
+}

--- a/providers/github/client.go
+++ b/providers/github/client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/boostsecurityio/poutine/analyze"
+	"github.com/boostsecurityio/poutine/providers/scm/domain"
 	"github.com/rs/zerolog/log"
 
 	"github.com/gofri/go-github-ratelimit/github_ratelimit"
@@ -19,10 +20,9 @@ import (
 )
 
 const GitHub string = "github"
-const defaultDomain string = "github.com"
 
 func NewGithubSCMClient(ctx context.Context, baseURL string, token string) (*ScmClient, error) {
-	domain := defaultDomain
+	domain := scm_domain.DefaultGitHubDomain
 	if baseURL != "" {
 		domain = baseURL
 	}
@@ -150,7 +150,7 @@ func NewClient(ctx context.Context, token string, domain string) (*Client, error
 		graphQLClient *githubv4.Client
 	)
 
-	if domain == defaultDomain {
+	if domain == scm_domain.DefaultGitHubDomain {
 		graphQLClient = githubv4.NewClient(httpClient)
 	} else {
 		baseURL := fmt.Sprintf("https://%s/", domain)

--- a/providers/gitlab/client.go
+++ b/providers/gitlab/client.go
@@ -8,13 +8,14 @@ import (
 	"strings"
 
 	"github.com/boostsecurityio/poutine/analyze"
+	"github.com/boostsecurityio/poutine/providers/scm/domain"
 	"github.com/xanzy/go-gitlab"
 )
 
 const GitLab string = "gitlab"
 
 func NewGitlabSCMClient(ctx context.Context, baseURL string, token string) (*ScmClient, error) {
-	domain := "gitlab.com"
+	domain := scm_domain.DefaultGitLabDomain
 	if baseURL != "" {
 		domain = baseURL
 	}

--- a/providers/scm/domain/scm_domain.go
+++ b/providers/scm/domain/scm_domain.go
@@ -1,9 +1,12 @@
-package scm
+package scm_domain
 
 import "strings"
 
 // ScmBaseDomain represent the base domain for a SCM provider.
 type ScmBaseDomain string
+
+const DefaultGitHubDomain string = "github.com"
+const DefaultGitLabDomain string = "gitlab.com"
 
 var schemePrefixes = []string{"https://", "http://"}
 

--- a/providers/scm/domain/scm_domain_test.go
+++ b/providers/scm/domain/scm_domain_test.go
@@ -1,4 +1,4 @@
-package scm
+package scm_domain
 
 import "testing"
 


### PR DESCRIPTION
This fixes #190.

Tested against an instance of GHES. It works for rules like "CI Runner Debug Enabled" and "Pull Request Runs on Self-Hosted GitHub Actions Runner" but not "GitHub Action from Unverified Creator used". That requires somehow passing the base domain to [`PurlFromGithubActions` and `PurlFromDockerImage`](https://github.com/boostsecurityio/poutine/blob/e259b09e5f955a241cb4510e8c188dbaa17292a7/models/purl.go#L62), which could be more complicated.