### PR TITLE
Fix Analyze Org Data Race

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -185,12 +185,11 @@ func GetAnalyzer(ctx context.Context, command string) (*analyze.Analyzer, error)
 }
 
 func newOpa(ctx context.Context) (*opa.Opa, error) {
-	opaClient, err := opa.NewOpa()
+	opaClient, err := opa.NewOpa(ctx, config)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create OPA client")
 		return nil, err
 	}
-	_ = opaClient.WithConfig(ctx, config)
 
 	return opaClient, nil
 }

--- a/opa/opa_test.go
+++ b/opa/opa_test.go
@@ -42,7 +42,9 @@ func TestOpaBuiltins(t *testing.T) {
 		},
 	}
 
-	opa, err := NewOpa()
+	opa, err := NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	noOpaErrors(t, err)
 
 	for _, c := range cases {
@@ -77,7 +79,9 @@ func TestSemverConstraintCheck(t *testing.T) {
 		},
 	}
 
-	opa, err := NewOpa()
+	opa, err := NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	noOpaErrors(t, err)
 
 	for _, c := range cases {
@@ -114,7 +118,9 @@ func TestJobUsesSelfHostedRunner(t *testing.T) {
 		"random-name":         true,
 	}
 
-	opa, err := NewOpa()
+	opa, err := NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	noOpaErrors(t, err)
 
 	for runner, expected := range cases {
@@ -136,7 +142,9 @@ func TestJobUsesSelfHostedRunner(t *testing.T) {
 }
 
 func TestWithConfig(t *testing.T) {
-	o, err := NewOpa()
+	o, err := NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	noOpaErrors(t, err)
 	ctx := context.TODO()
 
@@ -181,7 +189,9 @@ func TestCapabilities(t *testing.T) {
 }
 
 func TestRulesMetadataLevel(t *testing.T) {
-	opa, err := NewOpa()
+	opa, err := NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	noOpaErrors(t, err)
 
 	query := `{rule_id: rule.level |
@@ -202,7 +212,9 @@ func TestRulesMetadataLevel(t *testing.T) {
 }
 
 func TestWithRulesConfig(t *testing.T) {
-	o, err := NewOpa()
+	o, err := NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	noOpaErrors(t, err)
 	ctx := context.TODO()
 

--- a/scanner/inventory.go
+++ b/scanner/inventory.go
@@ -32,16 +32,25 @@ func NewInventory(opa *opa.Opa, pkgsupplyClient ReputationClient, provider strin
 }
 
 func (i *Inventory) AddPackage(ctx context.Context, pkg *models.PackageInsights, workdir string) error {
+	scannedPackage, err := i.ScanPackage(ctx, pkg, workdir)
+	if err != nil {
+		return err
+	}
+
+	i.Packages = append(i.Packages, scannedPackage)
+	return nil
+}
+
+func (i *Inventory) ScanPackage(ctx context.Context, pkg *models.PackageInsights, workdir string) (*models.PackageInsights, error) {
 	s := NewScanner(workdir)
 	s.Package = pkg
 
 	err := s.Run(ctx, i.opa)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	i.Packages = append(i.Packages, s.Package)
-	return nil
+	return s.Package, nil
 }
 
 func (i *Inventory) Purls() []string {

--- a/scanner/inventory_test.go
+++ b/scanner/inventory_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func TestPurls(t *testing.T) {
-	o, _ := opa.NewOpa()
+	o, _ := opa.NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	i := NewInventory(o, nil, "", "")
 	pkg := &models.PackageInsights{
 		Purl: "pkg:github/org/owner",
@@ -53,7 +55,9 @@ func TestPurls(t *testing.T) {
 }
 
 func TestFindings(t *testing.T) {
-	o, _ := opa.NewOpa()
+	o, _ := opa.NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	i := NewInventory(o, nil, "gitlab", "")
 	purl := "pkg:github/org/owner"
 	pkg := &models.PackageInsights{
@@ -426,7 +430,9 @@ func TestFindings(t *testing.T) {
 }
 
 func TestSkipRule(t *testing.T) {
-	o, _ := opa.NewOpa()
+	o, _ := opa.NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	i := NewInventory(o, nil, "", "")
 	ctx := context.TODO()
 	purl := "pkg:github/org/owner"
@@ -470,7 +476,9 @@ func TestSkipRule(t *testing.T) {
 }
 
 func TestRulesConfig(t *testing.T) {
-	o, _ := opa.NewOpa()
+	o, _ := opa.NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	i := NewInventory(o, nil, "", "")
 	ctx := context.TODO()
 	purl := "pkg:github/org/owner"

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -10,7 +10,9 @@ import (
 
 func TestGithubWorkflows(t *testing.T) {
 	s := NewScanner("testdata")
-	o, _ := opa.NewOpa()
+	o, _ := opa.NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	err := s.Run(context.TODO(), o)
 	workflows := s.Package.GithubActionsWorkflows
 
@@ -33,7 +35,9 @@ func TestGithubWorkflows(t *testing.T) {
 
 func TestGithubWorkflowsNotFound(t *testing.T) {
 	s := NewScanner("testdata/.github")
-	o, _ := opa.NewOpa()
+	o, _ := opa.NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	err := s.Run(context.TODO(), o)
 	workflows := s.Package.GithubActionsWorkflows
 
@@ -43,7 +47,9 @@ func TestGithubWorkflowsNotFound(t *testing.T) {
 
 func TestGithubActionsMetadata(t *testing.T) {
 	s := NewScanner("testdata")
-	o, _ := opa.NewOpa()
+	o, _ := opa.NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	err := s.Run(context.TODO(), o)
 
 	metadata := s.Package.GithubActionsMetadata
@@ -58,7 +64,9 @@ func TestGithubActionsMetadata(t *testing.T) {
 
 func TestRun(t *testing.T) {
 	s := NewScanner("testdata")
-	o, _ := opa.NewOpa()
+	o, _ := opa.NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	s.Package.Purl = "pkg:github/org/owner"
 
 	err := s.Run(context.TODO(), o)
@@ -73,7 +81,9 @@ func TestRun(t *testing.T) {
 
 func TestPipelineAsCodeTekton(t *testing.T) {
 	s := NewScanner("testdata")
-	o, _ := opa.NewOpa()
+	o, _ := opa.NewOpa(context.TODO(), &models.Config{
+		Include: []models.ConfigInclude{},
+	})
 	err := s.Run(context.TODO(), o)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Reworked analyze org to fix data race when accumulating scanned packages in the inventory to then proceed to the finalization of the analysis. Fixes #195 

Also reworked opa initialization. We initialize the opa compiler only once instead of every time the evaluation is called.