### PR TITLE
Gracefully skip empty repos

### DIFF
--- a/analyze/analyze.go
+++ b/analyze/analyze.go
@@ -137,6 +137,11 @@ func (a *Analyzer) AnalyzeOrg(ctx context.Context, org string, numberOfGoroutine
 				bar.ChangeMax(repoBatch.TotalCount - 1)
 				continue
 			}
+			if repo.GetSize() == 0 {
+				bar.ChangeMax(repoBatch.TotalCount - 1)
+				log.Info().Str("repo", repo.GetRepoIdentifier()).Msg("Skipping empty repository")
+				continue
+			}
 			if err := goRoutineLimitSem.Acquire(ctx, 1); err != nil {
 				close(errChan)
 				return fmt.Errorf("failed to acquire semaphore: %w", err)


### PR DESCRIPTION
This fixes #191.

(Or it should, this is admittedly a drive-by change I haven't tested.)