### PR TITLE
feat(rules): additional code execution commands for untrusted checkout exec

### DIFF
--- a/opa/rego/rules/untrusted_checkout_exec.rego
+++ b/opa/rego/rules/untrusted_checkout_exec.rego
@@ -45,6 +45,8 @@ build_commands[cmd] = {
 	"ant": {"^ant "},
 	"mkdocs": {"mkdocs build"},
 	"vale": {"vale "},
+	"pip": {"pip install", "pipenv install", "pipenv run "},
+	"cargo": {"cargo build", "cargo run"},
 }[cmd]
 
 results contains poutine.finding(rule, pkg_purl, {


### PR DESCRIPTION
# Changes to build commands
- Adds `pip` commands 
  - Code execution can be achieved via [`setup.py`](https://docs.python.org/3.11/distutils/setupscript.html) script after installing
- Adds `cargo` commands 
  - Code execution can be achieved via [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html) scripts which are invoked before build 