### PR TITLE
Set default Git branch for analyze_local

### DIFF
--- a/providers/local/client.go
+++ b/providers/local/client.go
@@ -181,7 +181,7 @@ func (gl Repo) GetSize() int {
 }
 
 func (gl Repo) GetDefaultBranch() string {
-	return ""
+	return "main"
 }
 
 func (gl Repo) GetLicense() string {


### PR DESCRIPTION
When testing against local repos, some rules may refer to `default_branch` which was set to empty string. We set a reasonable default value of `main`.