### PR TITLE
Optimize skip rule

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,12 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+
 	"github.com/boostsecurityio/poutine/analyze"
 	"github.com/boostsecurityio/poutine/formatters/json"
 	"github.com/boostsecurityio/poutine/formatters/pretty"
@@ -11,15 +17,10 @@ import (
 	"github.com/boostsecurityio/poutine/opa"
 	"github.com/boostsecurityio/poutine/providers/gitops"
 	"github.com/boostsecurityio/poutine/providers/scm"
-	"github.com/boostsecurityio/poutine/providers/scm/domain"
+	scm_domain "github.com/boostsecurityio/poutine/providers/scm/domain"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
-	"os"
-	"os/signal"
-	"path/filepath"
-	"strings"
-	"syscall"
 
 	"github.com/spf13/cobra"
 )
@@ -36,6 +37,7 @@ var (
 var token string
 var cfgFile string
 var config *models.Config = models.DefaultConfig()
+var skipRules []string
 
 var legacyFlags = []string{"-token", "-format", "-verbose", "-scm", "-scm-base-uri", "-threads"}
 
@@ -112,6 +114,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&ScmProvider, "scm", "s", "github", "SCM platform (github, gitlab)")
 	rootCmd.PersistentFlags().VarP(&ScmBaseURL, "scm-base-url", "b", "Base URI of the self-hosted SCM instance (optional)")
 	rootCmd.PersistentFlags().BoolVarP(&config.Quiet, "quiet", "q", false, "Disable progress output")
+	rootCmd.PersistentFlags().StringSliceVar(&skipRules, "skip", []string{}, "Skip rules by name. This add to the config file.")
 
 	viper.BindPFlag("quiet", rootCmd.PersistentFlags().Lookup("quiet"))
 }
@@ -186,6 +189,9 @@ func GetAnalyzer(ctx context.Context, command string) (*analyze.Analyzer, error)
 }
 
 func newOpa(ctx context.Context) (*opa.Opa, error) {
+	if len(skipRules) > 0 {
+		config.Skip = append(config.Skip, models.ConfigSkip{Rule: skipRules})
+	}
 	opaClient, err := opa.NewOpa(ctx, config)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create OPA client")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -114,7 +114,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&ScmProvider, "scm", "s", "github", "SCM platform (github, gitlab)")
 	rootCmd.PersistentFlags().VarP(&ScmBaseURL, "scm-base-url", "b", "Base URI of the self-hosted SCM instance (optional)")
 	rootCmd.PersistentFlags().BoolVarP(&config.Quiet, "quiet", "q", false, "Disable progress output")
-	rootCmd.PersistentFlags().StringSliceVar(&skipRules, "skip", []string{}, "Skip rules by name. This add to the config file.")
+	rootCmd.PersistentFlags().StringSliceVar(&skipRules, "skip", []string{}, "Adds rules to the configured skip list for the current run (optional)")
 
 	viper.BindPFlag("quiet", rootCmd.PersistentFlags().Lookup("quiet"))
 }

--- a/models/config.go
+++ b/models/config.go
@@ -9,6 +9,15 @@ type ConfigSkip struct {
 	Level StringList `json:"level,omitempty"`
 }
 
+func (c *ConfigSkip) HasOnlyRule() bool {
+	return len(c.Purl) == 0 &&
+		len(c.Path) == 0 &&
+		len(c.OsvId) == 0 &&
+		len(c.Job) == 0 &&
+		len(c.Level) == 0 &&
+		len(c.Rule) != 0
+}
+
 type ConfigInclude struct {
 	Path StringList `json:"path,omitempty"`
 }

--- a/opa/opa.go
+++ b/opa/opa.go
@@ -98,7 +98,7 @@ func (o *Opa) Compile(ctx context.Context, skip []string) error {
 			if filepath.Dir(path) == filepath.Join("rego", "rules") {
 				filename := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
 				if slices.Contains(skip, filename) {
-					return err
+					return nil
 				}
 			}
 		}

--- a/opa/opa.go
+++ b/opa/opa.go
@@ -5,6 +5,12 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
 	"github.com/boostsecurityio/poutine/models"
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/loader"
@@ -13,9 +19,6 @@ import (
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 	"github.com/open-policy-agent/opa/v1/topdown/print"
 	"github.com/rs/zerolog/log"
-	"io/fs"
-	"os"
-	"strings"
 )
 
 //go:embed rego
@@ -45,7 +48,14 @@ func NewOpa(ctx context.Context, config *models.Config) (*Opa, error) {
 		return nil, fmt.Errorf("failed to set opa with config: %w", err)
 	}
 
-	err = newOpa.Compile(ctx)
+	subset := []string{}
+	for _, skip := range config.Skip {
+		if skip.HasOnlyRule() {
+			subset = append(subset, skip.Rule...)
+		}
+	}
+
+	err = newOpa.Compile(ctx, subset)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize opa compiler: %w", err)
 	}
@@ -77,11 +87,20 @@ func (o *Opa) WithConfig(ctx context.Context, config *models.Config) error {
 	)
 }
 
-func (o *Opa) Compile(ctx context.Context) error {
+func (o *Opa) Compile(ctx context.Context, skip []string) error {
 	modules := make(map[string]string)
 	err := fs.WalkDir(regoFs, "rego", func(path string, d fs.DirEntry, err error) error {
 		if d.IsDir() {
 			return err
+		}
+
+		if len(skip) != 0 {
+			if filepath.Dir(path) == filepath.Join("rego", "rules") {
+				filename := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+				if slices.Contains(skip, filename) {
+					return err
+				}
+			}
 		}
 
 		content, err := regoFs.ReadFile(path)


### PR DESCRIPTION
**Feat: Add `--skip` CLI option and optimize skipped rule processing**

This PR introduces two key improvements:

1.  **New `--skip` Command-Line Option:**
    * Allows users to specify a list of rule IDs (e.g., `--skip rule1,rule2`) to be skipped during execution.
    * These rules are added to any rules already skipped via the configuration file.
    * This provides a convenient way to disable entire rules directly from the command line, overriding any partial skips defined in the configuration for the same rule ID (i.e., if partially skipped in config but fully skipped via CLI, the rule is fully skipped).

2.  **Performance Optimization for Skipped Rules:**
    * Previously, all rules were processed/compiled, and their results were filtered afterwards according to the skip configuration.
    * This change optimizes the process: Rules marked for *complete* skipping (either via config or the new `--skip` CLI option) are now identified *before* processing and are not compiled or executed.
    * This avoids unnecessary computation for fully skipped rules, improving performance. Partial rule filtering (e.g., based on specific findings like `osv_id`) still requires the rule to be processed first.