### PR TITLE
Add include option to CLI and config file

### DIFF
--- a/.poutine.sample.yml
+++ b/.poutine.sample.yml
@@ -47,3 +47,10 @@ skipExamples:
 # skip findings by OSV ID
 - osv_id:
   - GHSA-mcph-m25j-8j63
+
+
+# includes only this set of rules
+includeRules:
+- "pr_runs_on_self_hosted"
+- "unpinnable_action"
+- "github_action_from_unverified_creator_used"

--- a/.poutine.sample.yml
+++ b/.poutine.sample.yml
@@ -50,7 +50,7 @@ skipExamples:
 
 
 # includes only this set of rules
-includeRules:
+allowedRules:
 - "pr_runs_on_self_hosted"
 - "unpinnable_action"
 - "github_action_from_unverified_creator_used"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,7 @@ var token string
 var cfgFile string
 var config *models.Config = models.DefaultConfig()
 var skipRules []string
-var includeRules []string
+var allowedRules []string
 
 var legacyFlags = []string{"-token", "-format", "-verbose", "-scm", "-scm-base-uri", "-threads"}
 
@@ -116,7 +116,7 @@ func init() {
 	rootCmd.PersistentFlags().VarP(&ScmBaseURL, "scm-base-url", "b", "Base URI of the self-hosted SCM instance (optional)")
 	rootCmd.PersistentFlags().BoolVarP(&config.Quiet, "quiet", "q", false, "Disable progress output")
 	rootCmd.PersistentFlags().StringSliceVar(&skipRules, "skip", []string{}, "Adds rules to the configured skip list for the current run (optional)")
-	rootCmd.PersistentFlags().StringSliceVar(&includeRules, "include", []string{}, "Adds rules to the configured includeRules list for the current run (optional)")
+	rootCmd.PersistentFlags().StringSliceVar(&allowedRules, "allowed-rules", []string{}, "Overwrite the configured allowedRules list for the current run (optional)")
 
 	viper.BindPFlag("quiet", rootCmd.PersistentFlags().Lookup("quiet"))
 }
@@ -194,7 +194,9 @@ func newOpa(ctx context.Context) (*opa.Opa, error) {
 	if len(skipRules) > 0 {
 		config.Skip = append(config.Skip, models.ConfigSkip{Rule: skipRules})
 	}
-	config.IncludeRules = append(config.IncludeRules, includeRules...)
+	if len(allowedRules) > 0 {
+		config.AllowedRules = allowedRules
+	}
 	opaClient, err := opa.NewOpa(ctx, config)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create OPA client")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ var token string
 var cfgFile string
 var config *models.Config = models.DefaultConfig()
 var skipRules []string
+var includeRules []string
 
 var legacyFlags = []string{"-token", "-format", "-verbose", "-scm", "-scm-base-uri", "-threads"}
 
@@ -115,6 +116,7 @@ func init() {
 	rootCmd.PersistentFlags().VarP(&ScmBaseURL, "scm-base-url", "b", "Base URI of the self-hosted SCM instance (optional)")
 	rootCmd.PersistentFlags().BoolVarP(&config.Quiet, "quiet", "q", false, "Disable progress output")
 	rootCmd.PersistentFlags().StringSliceVar(&skipRules, "skip", []string{}, "Adds rules to the configured skip list for the current run (optional)")
+	rootCmd.PersistentFlags().StringSliceVar(&includeRules, "include", []string{}, "Adds rules to the configured includeRules list for the current run (optional)")
 
 	viper.BindPFlag("quiet", rootCmd.PersistentFlags().Lookup("quiet"))
 }
@@ -192,6 +194,7 @@ func newOpa(ctx context.Context) (*opa.Opa, error) {
 	if len(skipRules) > 0 {
 		config.Skip = append(config.Skip, models.ConfigSkip{Rule: skipRules})
 	}
+	config.IncludeRules = append(config.IncludeRules, includeRules...)
 	opaClient, err := opa.NewOpa(ctx, config)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create OPA client")

--- a/models/config.go
+++ b/models/config.go
@@ -24,7 +24,7 @@ type ConfigInclude struct {
 
 type Config struct {
 	Skip         []ConfigSkip                      `json:"skip"`
-	IncludeRules []string                          `json:"include_rules"`
+	AllowedRules []string                          `json:"allowed_rules"`
 	Include      []ConfigInclude                   `json:"include"`
 	IgnoreForks  bool                              `json:"ignore_forks"`
 	Quiet        bool                              `json:"quiet,omitempty"`

--- a/models/config.go
+++ b/models/config.go
@@ -23,11 +23,12 @@ type ConfigInclude struct {
 }
 
 type Config struct {
-	Skip        []ConfigSkip                      `json:"skip"`
-	Include     []ConfigInclude                   `json:"include"`
-	IgnoreForks bool                              `json:"ignore_forks"`
-	Quiet       bool                              `json:"quiet,omitempty"`
-	RulesConfig map[string]map[string]interface{} `json:"rules_config"`
+	Skip         []ConfigSkip                      `json:"skip"`
+	IncludeRules []string                          `json:"include_rules"`
+	Include      []ConfigInclude                   `json:"include"`
+	IgnoreForks  bool                              `json:"ignore_forks"`
+	Quiet        bool                              `json:"quiet,omitempty"`
+	RulesConfig  map[string]map[string]interface{} `json:"rules_config"`
 }
 
 func DefaultConfig() *Config {


### PR DESCRIPTION
New option to include only a set of rules via the CLI or config file. This is compatible with the existing skip option, since the skip options can be use to filter more specific results. If includes rules is empty, it is ignored.