### PR TITLE
Org stale branch

### DIFF
--- a/.poutine.sample.yml
+++ b/.poutine.sample.yml
@@ -47,3 +47,10 @@ skipExamples:
 # skip findings by OSV ID
 - osv_id:
   - GHSA-mcph-m25j-8j63
+
+
+# includes only this set of rules
+allowedRules:
+- "pr_runs_on_self_hosted"
+- "unpinnable_action"
+- "github_action_from_unverified_creator_used"

--- a/analyze/analyze.go
+++ b/analyze/analyze.go
@@ -3,6 +3,7 @@ package analyze
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -397,8 +398,8 @@ func (a *Analyzer) AnalyzeOrgStaleBranch(ctx context.Context, org string, number
 		}
 	}
 
-	bar.Set(len(repoInfos))
-	bar.Describe(fmt.Sprintf("Analyzing workflows matching %s", regex.String()))
+	_ = bar.Set(len(repoInfos))
+	bar.Describe("Analyzing workflows matching " + regex.String())
 
 	wgConsumer := sync.WaitGroup{}
 	wgProducer := sync.WaitGroup{}
@@ -428,7 +429,7 @@ func (a *Analyzer) AnalyzeOrgStaleBranch(ctx context.Context, org string, number
 		}
 		tmpDirRepo, ok := tmpDirs[repoInfos[blobSha][0].RepoName]
 		if !ok {
-			errChan <- fmt.Errorf("failed to get temp directory location")
+			errChan <- errors.New("failed to get temp directory location")
 			close(errChan)
 			break
 		}
@@ -479,7 +480,7 @@ func (a *Analyzer) AnalyzeOrgStaleBranch(ctx context.Context, org string, number
 	}
 
 	bar.Describe("Scanning package")
-	bar.Set(1)
+	_ = bar.Set(1)
 
 	inventoryScanner := scanner.InventoryScannerMem{
 		Files: files,

--- a/analyze/analyze.go
+++ b/analyze/analyze.go
@@ -319,7 +319,7 @@ func (a *Analyzer) AnalyzeOrgStaleBranch(ctx context.Context, org string, number
 			go func(repo Repository) {
 				defer goRoutineLimitSem.Release(1)
 				defer reposWg.Done()
-				defer bar.Add(1)
+				defer func() { _ = bar.Add(1) }()
 				repoNameWithOwner := repo.GetRepoIdentifier()
 				_, repoName, err := a.ScmClient.ParseRepoAndOrg(repoNameWithOwner)
 				if err != nil {
@@ -438,7 +438,7 @@ func (a *Analyzer) AnalyzeOrgStaleBranch(ctx context.Context, org string, number
 		go func(blobSha string, tmpDirRepo string) {
 			defer wgProducer.Done()
 			defer semaphore.Release(1)
-			defer bar.Add(1)
+			func() { _ = bar.Add(1) }()
 
 			match, content, err := a.GitClient.BlobMatches(ctx, tmpDirRepo, blobSha, regex)
 			if err != nil {

--- a/analyze/analyze.go
+++ b/analyze/analyze.go
@@ -238,7 +238,7 @@ func (a *Analyzer) AnalyzeOrgStaleBranch(ctx context.Context, org string, number
 	bar := a.progressBar(0, "Find unique workflows")
 
 	var reposWg sync.WaitGroup
-	errChan := make(chan error, 1)
+	errChan := make(chan error, maxGoroutines)
 	maxGoroutines := 2
 	if numberOfGoroutines != nil {
 		maxGoroutines = *numberOfGoroutines

--- a/cmd/analyzeOrgStaleBranches.go
+++ b/cmd/analyzeOrgStaleBranches.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var analyzeOrgStaleBranches = &cobra.Command{
+	Use:   "analyze_org_stale_branches",
+	Short: "Analyzes an organization's repositories for pull_request_target vulnerabilities in stale branches",
+	Long: `Analyzes an organization's repositories for pull_request_target vulnerabilities in stale branches, looping through all remote branches to find unique GitHub Actions workflows with old pull_request_target vulnerabilities, even though the default branch does not have that vulnerability anymore.
+Example: poutine analyze_org_stale_branches org --token "$GH_TOKEN"`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		token = viper.GetString("token")
+		ctx := cmd.Context()
+		analyzer, err := GetAnalyzer(ctx, "analyze_org_stale_branches")
+		if err != nil {
+			return fmt.Errorf("error getting analyzer analyze_org_stale_branches: %w", err)
+		}
+
+		if Format == "sarif" {
+			return errors.New("sarif formatter not supported for analyze_org_stale_branches")
+		}
+
+		repo := args[0]
+
+		reg, err := regexp.Compile(regex)
+		if err != nil {
+			return fmt.Errorf("error compiling regex: %w", err)
+		}
+
+		_, err = analyzer.AnalyzeOrgStaleBranch(ctx, repo, &threads, &expand, reg)
+		if err != nil {
+			return fmt.Errorf("failed to analyze repo %s: %w", repo, err)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(analyzeOrgStaleBranches)
+
+	analyzeOrgStaleBranches.Flags().StringVarP(&token, "token", "t", "", "SCM access token (env: GH_TOKEN)")
+	analyzeOrgStaleBranches.Flags().IntVarP(&threads, "threads", "j", 5, "Parallelization factor for scanning stale branches")
+	analyzeOrgStaleBranches.Flags().BoolVarP(&expand, "expand", "e", false, "Expand the output to the classic representation from analyze_repo")
+	analyzeOrgStaleBranches.Flags().StringVarP(&regex, "regex", "r", "pull_request_target", "Regex to check if the workflow is accessible in stale branches")
+
+	_ = viper.BindPFlag("token", analyzeOrgStaleBranches.Flags().Lookup("token"))
+	_ = viper.BindEnv("token", "GH_TOKEN")
+}

--- a/cmd/analyzeRepoStaleBranches.go
+++ b/cmd/analyzeRepoStaleBranches.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-var threadsRepoStaleBranch int
 var expand bool
 var regex string
 
@@ -38,7 +37,7 @@ Example Scanning a remote Github Repository: poutine analyze_repo_stale_branches
 			return fmt.Errorf("error compiling regex: %w", err)
 		}
 
-		_, err = analyzer.AnalyzeStaleBranches(ctx, repo, &threadsRepoStaleBranch, &expand, reg)
+		_, err = analyzer.AnalyzeStaleBranches(ctx, repo, &threads, &expand, reg)
 		if err != nil {
 			return fmt.Errorf("failed to analyze repo %s: %w", repo, err)
 		}
@@ -51,7 +50,7 @@ func init() {
 	rootCmd.AddCommand(analyzeRepoStaleBranches)
 
 	analyzeRepoStaleBranches.Flags().StringVarP(&token, "token", "t", "", "SCM access token (env: GH_TOKEN)")
-	analyzeRepoStaleBranches.Flags().IntVarP(&threadsRepoStaleBranch, "threads", "j", 5, "Parallelization factor for scanning stale branches")
+	analyzeRepoStaleBranches.Flags().IntVarP(&threads, "threads", "j", 5, "Parallelization factor for scanning stale branches")
 	analyzeRepoStaleBranches.Flags().BoolVarP(&expand, "expand", "e", false, "Expand the output to the classic representation from analyze_repo")
 	analyzeRepoStaleBranches.Flags().StringVarP(&regex, "regex", "r", "pull_request_target", "Regex to check if the workflow is accessible in stale branches")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ var token string
 var cfgFile string
 var config *models.Config = models.DefaultConfig()
 var skipRules []string
+var allowedRules []string
 
 var legacyFlags = []string{"-token", "-format", "-verbose", "-scm", "-scm-base-uri", "-threads"}
 
@@ -115,6 +116,7 @@ func init() {
 	rootCmd.PersistentFlags().VarP(&ScmBaseURL, "scm-base-url", "b", "Base URI of the self-hosted SCM instance (optional)")
 	rootCmd.PersistentFlags().BoolVarP(&config.Quiet, "quiet", "q", false, "Disable progress output")
 	rootCmd.PersistentFlags().StringSliceVar(&skipRules, "skip", []string{}, "Adds rules to the configured skip list for the current run (optional)")
+	rootCmd.PersistentFlags().StringSliceVar(&allowedRules, "allowed-rules", []string{}, "Overwrite the configured allowedRules list for the current run (optional)")
 
 	viper.BindPFlag("quiet", rootCmd.PersistentFlags().Lookup("quiet"))
 }
@@ -191,6 +193,9 @@ func GetAnalyzer(ctx context.Context, command string) (*analyze.Analyzer, error)
 func newOpa(ctx context.Context) (*opa.Opa, error) {
 	if len(skipRules) > 0 {
 		config.Skip = append(config.Skip, models.ConfigSkip{Rule: skipRules})
+	}
+	if len(allowedRules) > 0 {
+		config.AllowedRules = allowedRules
 	}
 	opaClient, err := opa.NewOpa(ctx, config)
 	if err != nil {

--- a/formatters/json/json.go
+++ b/formatters/json/json.go
@@ -64,7 +64,7 @@ func (f *Format) Format(ctx context.Context, packages []*models.PackageInsights)
 	return nil
 }
 
-func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageInsights, pathAssociations map[string][]models.RepoInfo) error {
+func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageInsights, pathAssociations map[string][]*models.RepoInfo) error {
 	var result struct {
 		Output string `json:"output"`
 		Error  string `json:"error"`

--- a/formatters/json/json.go
+++ b/formatters/json/json.go
@@ -64,7 +64,7 @@ func (f *Format) Format(ctx context.Context, packages []*models.PackageInsights)
 	return nil
 }
 
-func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageInsights, pathAssociations map[string][]models.BranchInfo) error {
+func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageInsights, pathAssociations map[string][]models.RepoInfo) error {
 	var result struct {
 		Output string `json:"output"`
 		Error  string `json:"error"`

--- a/formatters/pretty/pretty.go
+++ b/formatters/pretty/pretty.go
@@ -101,8 +101,16 @@ func (f *Format) printFindingsPerWorkflow(out io.Writer, results map[string]map[
 
 		blobshaTable[0][0] = blobsha
 
-		i := 0
+		// Extract and sort the keys of the findings map
+		sortedFindings := make([]string, 0, len(findings))
 		for finding := range findings {
+			sortedFindings = append(sortedFindings, finding)
+		}
+		sort.Strings(sortedFindings)
+
+		// Iterate over the sorted keys
+		i := 0
+		for _, finding := range sortedFindings {
 			blobshaTable[i][1] = finding
 			i++
 		}

--- a/formatters/pretty/pretty.go
+++ b/formatters/pretty/pretty.go
@@ -47,7 +47,7 @@ func (f *Format) Format(ctx context.Context, packages []*models.PackageInsights)
 	return nil
 }
 
-func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageInsights, pathAssociations map[string][]models.RepoInfo) error {
+func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageInsights, pathAssociations map[string][]*models.RepoInfo) error {
 	failures := map[string]int{}
 	rules := map[string]results.Rule{}
 
@@ -76,7 +76,7 @@ func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageI
 	return nil
 }
 
-func (f *Format) printFindingsPerWorkflow(out io.Writer, results map[string]map[string]bool, pathAssociations map[string][]models.RepoInfo) error {
+func (f *Format) printFindingsPerWorkflow(out io.Writer, results map[string]map[string]bool, pathAssociations map[string][]*models.RepoInfo) error {
 	// Skip rules with no findings.
 	table := tablewriter.NewWriter(out)
 	table.SetAutoMergeCells(true)

--- a/formatters/pretty/pretty.go
+++ b/formatters/pretty/pretty.go
@@ -52,44 +52,47 @@ func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageI
 	rules := map[string]results.Rule{}
 
 	for _, pkg := range packages {
-		findings := map[string][]string{}
+		findings := make(map[string]map[string]bool)
 		for _, finding := range pkg.FindingsResults.Findings {
-			failures[finding.RuleId]++
 			filename := filepath.Base(finding.Meta.Path)
 			filename = strings.TrimSuffix(filename, filepath.Ext(filename))
-			findings[filename] = append(findings[filename], finding.RuleId)
+			if _, ok := findings[filename]; !ok {
+				findings[filename] = make(map[string]bool)
+			}
+			if _, ok := findings[filename][finding.RuleId]; !ok {
+				failures[finding.RuleId]++
+			}
+			findings[filename][finding.RuleId] = true
 		}
 
 		for _, rule := range pkg.FindingsResults.Rules {
 			rules[rule.Id] = rule
 		}
 
-		_ = f.printFindingsPerWorkflow(os.Stdout, findings, pkg.Purl, nil)
+		_ = f.printFindingsPerWorkflow(os.Stdout, findings, pathAssociations)
 	}
 	printSummaryTable(os.Stdout, failures, rules)
 
 	return nil
 }
 
-func (f *Format) printFindingsPerWorkflow(out io.Writer, results map[string][]string, purlStr string, pathAssociations map[string][]models.BranchInfo) error {
+func (f *Format) printFindingsPerWorkflow(out io.Writer, results map[string]map[string]bool, pathAssociations map[string][]models.RepoInfo) error {
 	// Skip rules with no findings.
 	table := tablewriter.NewWriter(out)
 	table.SetAutoMergeCells(true)
-	table.SetHeader([]string{"Workflow sha", "Rule", "Branch", "URL"})
+	table.SetHeader([]string{"Workflow sha", "Rule", "Location", "URL"})
 
-	purl, err := models.NewPurl(purlStr)
-	if err != nil {
-		return fmt.Errorf("error creating purl: %w", err)
-	}
-	for blobsha, branchInfos := range pathAssociations {
+	for blobsha, repoInfos := range pathAssociations {
 		findings := results[blobsha]
 		if len(findings) == 0 {
 			continue
 		}
 		largestElement := len(findings)
 		sumPath := 0
-		for _, branchInfo := range branchInfos {
-			sumPath += len(branchInfo.FilePath)
+		for _, repoInfo := range repoInfos {
+			for _, branchInfo := range repoInfo.BranchInfos {
+				sumPath += len(branchInfo.FilePath)
+			}
 		}
 		blobshaTable := make([][]string, max(largestElement, sumPath))
 		for i := range blobshaTable {
@@ -98,19 +101,27 @@ func (f *Format) printFindingsPerWorkflow(out io.Writer, results map[string][]st
 
 		blobshaTable[0][0] = blobsha
 
-		for i, finding := range findings {
+		i := 0
+		for finding := range findings {
 			blobshaTable[i][1] = finding
+			i++
 		}
 
 		index := 0
-		for _, branchInfo := range branchInfos {
-			for j, path := range branchInfo.FilePath {
-				if j == 0 {
-					blobshaTable[index][2] = branchInfo.BranchName
-				}
+		for _, repoInfo := range repoInfos {
+			purl, err := models.NewPurl(repoInfo.Purl)
+			if err != nil {
+				return fmt.Errorf("failed to parse purl: %w", err)
+			}
+			for _, branchInfo := range repoInfo.BranchInfos {
+				for j, path := range branchInfo.FilePath {
+					if j == 0 {
+						blobshaTable[index][2] = repoInfo.RepoName + "/" + branchInfo.BranchName
+					}
 
-				blobshaTable[index][3] = purl.Link() + "/tree/" + branchInfo.BranchName + "/" + path
-				index += 1
+					blobshaTable[index][3] = purl.Link() + "/tree/" + branchInfo.BranchName + "/" + path
+					index += 1
+				}
 			}
 		}
 

--- a/formatters/pretty/pretty.go
+++ b/formatters/pretty/pretty.go
@@ -47,7 +47,7 @@ func (f *Format) Format(ctx context.Context, packages []*models.PackageInsights)
 	return nil
 }
 
-func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageInsights, pathAssociations map[string][]models.BranchInfo) error {
+func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageInsights, pathAssociations map[string][]models.RepoInfo) error {
 	failures := map[string]int{}
 	rules := map[string]results.Rule{}
 
@@ -64,7 +64,7 @@ func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageI
 			rules[rule.Id] = rule
 		}
 
-		_ = f.printFindingsPerWorkflow(os.Stdout, findings, pkg.Purl, pathAssociations)
+		_ = f.printFindingsPerWorkflow(os.Stdout, findings, pkg.Purl, nil)
 	}
 	printSummaryTable(os.Stdout, failures, rules)
 

--- a/formatters/sarif/sarif.go
+++ b/formatters/sarif/sarif.go
@@ -117,6 +117,6 @@ func (f *Format) Format(ctx context.Context, packages []*models.PackageInsights)
 	return nil
 }
 
-func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageInsights, pathAssociations map[string][]models.BranchInfo) error {
+func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageInsights, pathAssociations map[string][]models.RepoInfo) error {
 	return errors.New("not implemented")
 }

--- a/formatters/sarif/sarif.go
+++ b/formatters/sarif/sarif.go
@@ -117,6 +117,6 @@ func (f *Format) Format(ctx context.Context, packages []*models.PackageInsights)
 	return nil
 }
 
-func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageInsights, pathAssociations map[string][]models.RepoInfo) error {
+func (f *Format) FormatWithPath(ctx context.Context, packages []*models.PackageInsights, pathAssociations map[string][]*models.RepoInfo) error {
 	return errors.New("not implemented")
 }

--- a/models/branch_info.go
+++ b/models/branch_info.go
@@ -6,6 +6,7 @@ type BranchInfo struct {
 }
 
 type RepoInfo struct {
+	Purl        string       `json:"purl"`
 	RepoName    string       `json:"repo_name"`
 	BranchInfos []BranchInfo `json:"branch_infos"`
 }

--- a/models/branch_info.go
+++ b/models/branch_info.go
@@ -4,3 +4,8 @@ type BranchInfo struct {
 	BranchName string   `json:"branch_name"`
 	FilePath   []string `json:"file_path"`
 }
+
+type RepoInfo struct {
+	RepoName    string       `json:"repo_name"`
+	BranchInfos []BranchInfo `json:"branch_infos"`
+}

--- a/models/config.go
+++ b/models/config.go
@@ -23,11 +23,12 @@ type ConfigInclude struct {
 }
 
 type Config struct {
-	Skip        []ConfigSkip                      `json:"skip"`
-	Include     []ConfigInclude                   `json:"include"`
-	IgnoreForks bool                              `json:"ignore_forks"`
-	Quiet       bool                              `json:"quiet,omitempty"`
-	RulesConfig map[string]map[string]interface{} `json:"rules_config"`
+	Skip         []ConfigSkip                      `json:"skip"`
+	AllowedRules []string                          `json:"allowed_rules"`
+	Include      []ConfigInclude                   `json:"include"`
+	IgnoreForks  bool                              `json:"ignore_forks"`
+	Quiet        bool                              `json:"quiet,omitempty"`
+	RulesConfig  map[string]map[string]interface{} `json:"rules_config"`
 }
 
 func DefaultConfig() *Config {

--- a/providers/github/client.go
+++ b/providers/github/client.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/boostsecurityio/poutine/analyze"
-	"github.com/boostsecurityio/poutine/providers/scm/domain"
+	scm_domain "github.com/boostsecurityio/poutine/providers/scm/domain"
 	"github.com/rs/zerolog/log"
 
 	"github.com/gofri/go-github-ratelimit/github_ratelimit"

--- a/providers/github/client.go
+++ b/providers/github/client.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/boostsecurityio/poutine/analyze"
-	scm_domain "github.com/boostsecurityio/poutine/providers/scm/domain"
+	"github.com/boostsecurityio/poutine/providers/scm/domain"
 	"github.com/rs/zerolog/log"
 
 	"github.com/gofri/go-github-ratelimit/github_ratelimit"

--- a/scanner/inventory.go
+++ b/scanner/inventory.go
@@ -30,7 +30,11 @@ func NewInventory(opa *opa.Opa, pkgSupplyClient ReputationClient, provider strin
 	}
 }
 
-func (i *Inventory) ScanPackageScanner(ctx context.Context, pkgInsights models.PackageInsights, inventoryScanner *InventoryScanner) (*models.PackageInsights, error) {
+type InventoryScannerI interface {
+	Run(pkgInsights *models.PackageInsights) error
+}
+
+func (i *Inventory) ScanPackageScanner(ctx context.Context, pkgInsights models.PackageInsights, inventoryScanner InventoryScannerI) (*models.PackageInsights, error) {
 	refPkgInsights := &pkgInsights
 
 	if err := inventoryScanner.Run(refPkgInsights); err != nil {

--- a/scanner/inventory_scanner_mem.go
+++ b/scanner/inventory_scanner_mem.go
@@ -17,19 +17,6 @@ type InventoryScannerMem struct {
 	Parsers []MemParser
 }
 
-func NewInventoryScannerMem(files map[string][]byte) *InventoryScannerMem {
-	return &InventoryScannerMem{
-		Files: files,
-		Parsers: []MemParser{
-			NewGithubActionsMetadataParser(),
-			NewGithubActionWorkflowParser(),
-			NewAzurePipelinesParser(),
-			NewGitlabCiParser(),
-			NewPipelineAsCodeTektonParser(),
-		},
-	}
-}
-
 func (s *InventoryScannerMem) Run(pkgInsights *models.PackageInsights) error {
 	for path, data := range s.Files {
 		for _, parser := range s.Parsers {

--- a/scanner/inventory_scanner_mem.go
+++ b/scanner/inventory_scanner_mem.go
@@ -1,0 +1,45 @@
+package scanner
+
+import (
+	"regexp"
+
+	"github.com/boostsecurityio/poutine/models"
+	"github.com/rs/zerolog/log"
+)
+
+type MemParser interface {
+	MatchPattern() *regexp.Regexp
+	ParseFromMemory(data []byte, filePath string, pkgInsights *models.PackageInsights) error
+}
+
+type InventoryScannerMem struct {
+	Files   map[string][]byte
+	Parsers []MemParser
+}
+
+func NewInventoryScannerMem(files map[string][]byte) *InventoryScannerMem {
+	return &InventoryScannerMem{
+		Files: files,
+		Parsers: []MemParser{
+			NewGithubActionsMetadataParser(),
+			NewGithubActionWorkflowParser(),
+			NewAzurePipelinesParser(),
+			NewGitlabCiParser(),
+			NewPipelineAsCodeTektonParser(),
+		},
+	}
+}
+
+func (s *InventoryScannerMem) Run(pkgInsights *models.PackageInsights) error {
+	for path, data := range s.Files {
+		for _, parser := range s.Parsers {
+			if !parser.MatchPattern().MatchString(path) {
+				continue
+			}
+			if err := parser.ParseFromMemory(data, path, pkgInsights); err != nil {
+				log.Error().Str("file", path).Err(err).Msg("error parsing matched file")
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Add:
- analyze_org_stale_branches which extends analyze_repo_stale_branches capabilities by integrating analyze_org optimizations and check for duplication over the entire org.
- Add in memory scanner option so stale branch analysis doesn't require to write to the file system.
- Fix a pretty format error when one workflow has multiple of the same vulnerability.
- Generalize the FormatWithPath print to work with  analyze_org_stale_branches and analyze_repo_stale_branches.

On large org, this might be throttled by github and crash, like analyze_repo.