### PR TITLE
feat(config): discover .github/poutine.yml as a config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ poutine analyze_org my-org/project --token "$GL_TOKEN" --scm gitlab --scm-base-u
 --scm                SCM platform (default: github, gitlab)
 --scm-base-url       Base URI of the self-hosted SCM instance
 --threads            Number of threads to use (default: 2)
---config             Path to the configuration file (default: .poutine.yml)
+--config             Path to the configuration file (default: .poutine.yml in the working directory, or .github/poutine.yml)
 --skip               Add rules to the skip list for the current run (can be specified multiple times)
 --verbose            Enable debug logging
 --fail-on-violation  Exit with a non-zero code (10) when violations are found
@@ -125,7 +125,7 @@ See [.poutine.sample.yml](.poutine.sample.yml) for an example configuration file
 
 #### Configuration
 
-Create a `.poutine.yml` configuration file in your current working directory, or use a custom path with the `--config` flag:
+Create a `.poutine.yml` configuration file in your current working directory, or keep it alongside your other GitHub metadata at `.github/poutine.yml` — both are auto-discovered. When both exist, `.poutine.yml` at the repo root wins. To use a custom path, pass the `--config` flag (which takes precedence over both):
 
 ```bash
 poutine analyze_local . --config my-config.yml

--- a/cmd/config_discovery_test.go
+++ b/cmd/config_discovery_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindDefaultConfigFile_NoConfig(t *testing.T) {
+	dir := t.TempDir()
+	assert.Empty(t, findDefaultConfigFile(dir))
+}
+
+func TestFindDefaultConfigFile_RootYml(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".poutine.yml")
+	require.NoError(t, os.WriteFile(path, []byte("ignoreForks: true\n"), 0o644))
+
+	assert.Equal(t, path, findDefaultConfigFile(dir))
+}
+
+func TestFindDefaultConfigFile_RootYaml(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".poutine.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("ignoreForks: true\n"), 0o644))
+
+	assert.Equal(t, path, findDefaultConfigFile(dir))
+}
+
+func TestFindDefaultConfigFile_GithubDir(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".github"), 0o755))
+	path := filepath.Join(dir, ".github", "poutine.yml")
+	require.NoError(t, os.WriteFile(path, []byte("ignoreForks: true\n"), 0o644))
+
+	assert.Equal(t, path, findDefaultConfigFile(dir))
+}
+
+func TestFindDefaultConfigFile_RootTakesPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	rootPath := filepath.Join(dir, ".poutine.yml")
+	require.NoError(t, os.WriteFile(rootPath, []byte("ignoreForks: true\n"), 0o644))
+
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".github"), 0o755))
+	ghPath := filepath.Join(dir, ".github", "poutine.yml")
+	require.NoError(t, os.WriteFile(ghPath, []byte("ignoreForks: false\n"), 0o644))
+
+	assert.Equal(t, rootPath, findDefaultConfigFile(dir),
+		"`.poutine.yml` at repo root must take precedence over `.github/poutine.yml`")
+}
+
+// TestFindDefaultConfigFile_IgnoresDirectoryNamedLikeConfig ensures that a
+// directory (rather than a file) at a candidate path is skipped — otherwise
+// a stray `.poutine.yml/` dir would be wrongly reported as the config file.
+func TestFindDefaultConfigFile_IgnoresDirectoryNamedLikeConfig(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".poutine.yml"), 0o755))
+
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".github"), 0o755))
+	ghPath := filepath.Join(dir, ".github", "poutine.yml")
+	require.NoError(t, os.WriteFile(ghPath, []byte("ignoreForks: true\n"), 0o644))
+
+	assert.Equal(t, ghPath, findDefaultConfigFile(dir))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,7 +138,7 @@ func init() {
 		}
 	}
 
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is .poutine.yml in the current directory)")
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is .poutine.yml in the current directory or .github/poutine.yml)")
 	RootCmd.PersistentFlags().StringVarP(&Format, "format", "f", "pretty", "Output format (pretty, json, sarif)")
 	RootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "Enable verbose logging")
 	RootCmd.PersistentFlags().StringVarP(&ScmProvider, "scm", "s", "github", "SCM platform (github, gitlab)")
@@ -153,26 +153,51 @@ func init() {
 
 func initConfig() {
 	viper.AutomaticEnv()
-	if cfgFile != "" {
-		viper.SetConfigFile(cfgFile)
-	} else {
-		viper.AddConfigPath(".")
-		viper.SetConfigName(".poutine")
+
+	configPath := cfgFile
+	if configPath == "" {
+		configPath = findDefaultConfigFile(".")
 	}
 
+	if configPath == "" {
+		return
+	}
+
+	viper.SetConfigFile(configPath)
 	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			return
-		} else {
-			log.Error().Err(err).Msg("Can't read config")
-			os.Exit(1)
-		}
+		log.Error().Err(err).Msg("Can't read config")
+		os.Exit(1)
 	}
 
 	if err := viper.Unmarshal(&config); err != nil {
 		log.Error().Err(err).Msg("Unable to unmarshal config")
 		os.Exit(1)
 	}
+}
+
+// findDefaultConfigFile returns the path of the first default config file
+// found under baseDir, in order of precedence:
+//  1. <baseDir>/.poutine.<ext>        (repo root)
+//  2. <baseDir>/.github/poutine.<ext> (GitHub convention — no leading dot)
+//
+// Extensions are those supported by viper (yml, yaml, json, toml, ...).
+// Returns "" if no default config file is found.
+func findDefaultConfigFile(baseDir string) string {
+	candidates := []struct {
+		dir, name string
+	}{
+		{baseDir, ".poutine"},
+		{filepath.Join(baseDir, ".github"), "poutine"},
+	}
+	for _, c := range candidates {
+		for _, ext := range viper.SupportedExts {
+			path := filepath.Join(c.dir, c.name+"."+ext)
+			if info, err := os.Stat(path); err == nil && !info.IsDir() {
+				return path
+			}
+		}
+	}
+	return ""
 }
 
 func cleanup() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -177,7 +177,7 @@ func initConfig() {
 
 // findDefaultConfigFile returns the path of the first default config file
 // found under baseDir, in order of precedence:
-//  1. <baseDir>/.poutine.<ext>        (repo root)
+//  1. <baseDir>/.poutine.<ext>        (working directory)
 //  2. <baseDir>/.github/poutine.<ext> (GitHub convention — no leading dot)
 //
 // Extensions are those supported by viper (yml, yaml, json, toml, ...).


### PR DESCRIPTION
Hi @fproulx-boostsecurity — thanks for the invitation on #422, happy to pick this up!

This adds `.github/poutine.yml` as a secondary auto-discovery path, so the config can live alongside the other `.github/` metadata (dependabot, codeowners, …) instead of cluttering the repo root. No leading dot when under `.github/`, matching what zizmor and friends do.

Precedence, highest wins:

1. `--config <path>` flag
2. `.poutine.<ext>` in the working directory
3. `.github/poutine.<ext>`

`.poutine.yml` at the root still wins when both defaults are present, so existing setups are untouched. Extensions probed are whatever viper supports (yml, yaml, json, toml, …), same as before.

Changes:

- `cmd/root.go` — pulled the default lookup into a small `findDefaultConfigFile` helper so the precedence is explicit and testable.
- `cmd/config_discovery_test.go` — unit tests for each branch (no config, root `.yml`/`.yaml`, `.github/poutine.yml`, root-wins-over-`.github`, plus a guard that a directory named like the config file is skipped).
- `README.md` — documented the new path and the precedence.

Ran locally: `go build ./...`, `go vet ./...`, `gofmt -l cmd/` (clean), `go test ./...` (green).

Small note: I used Claude to help author this PR — I was short on time and don't work in Go regularly. I've read through every change and run the full test suite, and I'm happy to iterate on whatever you'd like tweaked.

Cheers!

Signed-off-by: graelo <graelo@graelo.cc>