### PR TITLE
feat(config): discover .github/poutine.yml as a config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ poutine analyze_org my-org/project --token "$GL_TOKEN" --scm gitlab --scm-base-u
 --scm                SCM platform (default: github, gitlab)
 --scm-base-url       Base URI of the self-hosted SCM instance
 --threads            Number of threads to use (default: 2)
---config             Path to the configuration file (default: .poutine.yml)
+--config             Path to the configuration file (default: .poutine.yml in the current directory, then .github/poutine.yml)
 --skip               Add rules to the skip list for the current run (can be specified multiple times)
 --verbose            Enable debug logging
 --fail-on-violation  Exit with a non-zero code (10) when violations are found
@@ -130,6 +130,8 @@ Create a `.poutine.yml` configuration file in your current working directory, or
 ```bash
 poutine analyze_local . --config my-config.yml
 ```
+
+If a `.poutine.yml` file is not present at the repository root, poutine also looks for `.github/poutine.yml` so CI-related configuration can be grouped alongside other GitHub configuration files. A file at the repository root takes precedence over one under `.github/`, and the `--config` flag overrides both.
 
 In your configuration file, specify the path(s) to your custom rules using the `include` directive:
 

--- a/cmd/discover_config_test.go
+++ b/cmd/discover_config_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// chdir switches the working directory for the duration of the test and
+// restores it afterwards.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		_ = os.Chdir(prev)
+	})
+}
+
+func TestDiscoverConfigFile_NoFile(t *testing.T) {
+	chdir(t, t.TempDir())
+	assert.Equal(t, "", discoverConfigFile())
+}
+
+func TestDiscoverConfigFile_RootTakesPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".poutine.yml"), []byte("allowedRules:\n  - a\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".github"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".github", "poutine.yml"), []byte("allowedRules:\n  - b\n"), 0o644))
+	chdir(t, dir)
+
+	assert.Equal(t, ".poutine.yml", discoverConfigFile())
+}
+
+func TestDiscoverConfigFile_GithubFallback(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".github"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".github", "poutine.yml"), []byte("allowedRules:\n  - b\n"), 0o644))
+	chdir(t, dir)
+
+	assert.Equal(t, filepath.Join(".github", "poutine.yml"), discoverConfigFile())
+}
+
+func TestDiscoverConfigFile_IgnoresDirectories(t *testing.T) {
+	dir := t.TempDir()
+	// .poutine.yml exists as a directory; it must be ignored.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".poutine.yml"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".github"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".github", "poutine.yaml"), []byte("allowedRules:\n  - b\n"), 0o644))
+	chdir(t, dir)
+
+	assert.Equal(t, filepath.Join(".github", "poutine.yaml"), discoverConfigFile())
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,7 +138,7 @@ func init() {
 		}
 	}
 
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is .poutine.yml in the current directory)")
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default searches .poutine.yml in the current directory, then .github/poutine.yml)")
 	RootCmd.PersistentFlags().StringVarP(&Format, "format", "f", "pretty", "Output format (pretty, json, sarif)")
 	RootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "Enable verbose logging")
 	RootCmd.PersistentFlags().StringVarP(&ScmProvider, "scm", "s", "github", "SCM platform (github, gitlab)")
@@ -155,6 +155,8 @@ func initConfig() {
 	viper.AutomaticEnv()
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
+	} else if path := discoverConfigFile(); path != "" {
+		viper.SetConfigFile(path)
 	} else {
 		viper.AddConfigPath(".")
 		viper.SetConfigName(".poutine")
@@ -173,6 +175,26 @@ func initConfig() {
 		log.Error().Err(err).Msg("Unable to unmarshal config")
 		os.Exit(1)
 	}
+}
+
+// discoverConfigFile returns the first existing poutine config file in the
+// documented precedence order: .poutine.{ext} in the current directory, then
+// .github/poutine.{ext}. It returns an empty string when no file is found, in
+// which case viper's own search is used so the resulting ConfigFileNotFoundError
+// can still be handled uniformly.
+func discoverConfigFile() string {
+	// Supported extensions are the common subset viper parses natively.
+	extensions := []string{"yml", "yaml", "json", "toml"}
+	candidates := []string{".poutine", filepath.Join(".github", "poutine")}
+	for _, base := range candidates {
+		for _, ext := range extensions {
+			p := base + "." + ext
+			if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+				return p
+			}
+		}
+	}
+	return ""
 }
 
 func cleanup() {


### PR DESCRIPTION
Closes #422

## Summary

When `--config` is not provided, poutine now checks two locations for its configuration file, in priority order:

1. `.poutine.{yml,yaml,json,toml}` at the repository root (existing behaviour).
2. `.github/poutine.{yml,yaml,json,toml}`.

This lets users keep CI-related configuration under `.github/` alongside `dependabot.yml`, `CODEOWNERS`, etc. — the pattern mentioned in the issue and used by tools like zizmor. Root-level `.poutine.yml` still wins if both exist, so existing repositories are unaffected.

## Implementation

`cmd/root.go` — added a small `discoverConfigFile()` helper that walks the two candidate paths and returns the first existing file. When that helper returns a non-empty path, `initConfig` calls `viper.SetConfigFile()` on it; when it returns `""`, the existing viper search (`AddConfigPath(".") + SetConfigName(".poutine")`) still runs, so the `ConfigFileNotFoundError` path is unchanged.

Using `SetConfigFile` on the resolved path is cleaner than juggling `viper.AddConfigPath` / `SetConfigName` for two differently-named files, and it keeps the error-handling branch identical for both discovery and the "no config" case.

## Tests

`cmd/discover_config_test.go` covers:

- No config file present
- `.poutine.yml` at root takes precedence over `.github/poutine.yml`
- `.github/poutine.yml` used when root is absent
- Directory entries named `.poutine.yml` are ignored (defence against stray `mkdir`)

```
go test ./cmd/...
ok  	github.com/boostsecurityio/poutine/cmd	0.767s
```

Also smoke-tested the built binary in three temp directories (root config, `.github` config, and no config) — all succeed and use the expected file.

## Docs

Updated the `--config` flag help text and the README "Configuration" section to mention the new fallback path and note the precedence order. The CLI flag string now reads `config file (default searches .poutine.yml in the current directory, then .github/poutine.yml)`.
