### PR TITLE
fix typo in the GitHub word

### DIFF
--- a/cmd/analyzeRepo.go
+++ b/cmd/analyzeRepo.go
@@ -14,7 +14,7 @@ var analyzeRepoCmd = &cobra.Command{
 	Use:   "analyze_repo",
 	Short: "Analyzes a remote repository for supply chain vulnerabilities",
 	Long: `Analyzes a remote repository for supply chain vulnerabilities
-Example Scanning a remote Github Repository: poutine analyze_repo org/repo --token "$GH_TOKEN"`,
+Example Scanning a remote GitHub Repository: poutine analyze_repo org/repo --token "$GH_TOKEN"`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		Token = viper.GetString("token")

--- a/cmd/analyzeRepoStaleBranches.go
+++ b/cmd/analyzeRepoStaleBranches.go
@@ -16,7 +16,7 @@ var analyzeRepoStaleBranches = &cobra.Command{
 	Use:   "analyze_repo_stale_branches",
 	Short: "Analyzes a remote repository for pull_request_target vulnerabilities in stale branches",
 	Long: `Analyzes a remote repository, looping through all remote branches to find unique GitHub Actions workflows with old pull_request_target vulnerabilities, even though the default branch does not have that vulnerability anymore.
-Example Scanning a remote Github Repository: poutine analyze_repo_stale_branches org/repo --token "$GH_TOKEN"`,
+Example Scanning a remote GitHub Repository: poutine analyze_repo_stale_branches org/repo --token "$GH_TOKEN"`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		Token = viper.GetString("token")

--- a/docs/content/en/rules/github_action_from_unverified_creator_used.md
+++ b/docs/content/en/rules/github_action_from_unverified_creator_used.md
@@ -1,5 +1,5 @@
 ---
-title: "Github Action from Unverified Creator used"
+title: "GitHub Action from Unverified Creator used"
 slug: github_action_from_unverified_creator_used
 url: /rules/github_action_from_unverified_creator_used/
 rule: github_action_from_unverified_creator_used

--- a/docs/content/en/rules/if_always_true.md
+++ b/docs/content/en/rules/if_always_true.md
@@ -56,6 +56,6 @@ jobs:
 
 
 ## See Also
-- [Expression Always True Github Issue](https://github.com/actions/runner/issues/1173)
+- [Expression Always True GitHub Issue](https://github.com/actions/runner/issues/1173)
 - [About expressions](https://docs.github.com/en/actions/learn-github-actions/expressions#about-expressions)
 - [jobs<job_id>.if](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif)

--- a/docs/content/en/rules/known_vulnerability_in_build_platform.md
+++ b/docs/content/en/rules/known_vulnerability_in_build_platform.md
@@ -16,4 +16,4 @@ Upgrade the self-hosted provider to a non-vulnerable version.
 
 ## See Also
 - [Upgrade Gitlab](https://docs.gitlab.com/ee/update/)
-- [Upgrade Github Enterprise Server](https://docs.github.com/en/enterprise-server@3.13/admin/overview/about-upgrades-to-new-releases)
+- [Upgrade GitHub Enterprise Server](https://docs.github.com/en/enterprise-server@3.13/admin/overview/about-upgrades-to-new-releases)

--- a/docs/content/en/rules/pr_runs_on_self_hosted.md
+++ b/docs/content/en/rules/pr_runs_on_self_hosted.md
@@ -35,4 +35,4 @@ Having a GitHub Organization **Runners** configuration set to **All repositories
 - [Hardening for self-hosted runners](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#hardening-for-self-hosted-runners)
 - [Playing with fire - How we executed a critical supply chain attack on pytorch](https://johnstawinski.com/2024/01/11/playing-with-fire-how-we-executed-a-critical-supply-chain-attack-on-pytorch/)
 - [TensorFlow Supply Chain Compromise via Self-Hosted Runner Attack](https://www.praetorian.com/blog/tensorflow-supply-chain-compromise-via-self-hosted-runner-attack/)
-- [Gato - Github Attack TOOlkit](https://github.com/praetorian-inc/gato)
+- [Gato - GitHub Attack TOOlkit](https://github.com/praetorian-inc/gato)

--- a/formatters/sarif/sarif_test.go
+++ b/formatters/sarif/sarif_test.go
@@ -44,7 +44,7 @@ func TestSarifFormatBuildDependencyFindings(t *testing.T) {
 			Rules: map[string]results.Rule{
 				"github_action_from_unverified_creator_used": {
 					Id:          "github_action_from_unverified_creator_used",
-					Title:       "Github Action from Unverified Creator used",
+					Title:       "GitHub Action from Unverified Creator used",
 					Description: "Usage of GitHub Actions from unverified creators was detected.",
 					Level:       "note",
 				},

--- a/opa/rego/external/build_platform.rego
+++ b/opa/rego/external/build_platform.rego
@@ -258,7 +258,7 @@ advisories = {
 			"osv_id": "CVE-2022-23733",
 			"published": "2022-08-02T16:05:14",
 			"aliases": [],
-			"summary": "A stored XSS vulnerability was identified in GitHub Enterprise Server that allowed the injection of arbitrary attributes. This injection was blocked by Github's Content Security Policy (CSP). This vulnerability affected all versions of GitHub Enterprise Server prior to 3.6 and was fixed in versions 3.3.11, 3.4.6 and 3.5.3. This vulnerability was reported via the GitHub Bug Bounty program.",
+			"summary": "A stored XSS vulnerability was identified in GitHub Enterprise Server that allowed the injection of arbitrary attributes. This injection was blocked by GitHub's Content Security Policy (CSP). This vulnerability affected all versions of GitHub Enterprise Server prior to 3.6 and was fixed in versions 3.3.11, 3.4.6 and 3.5.3. This vulnerability was reported via the GitHub Bug Bounty program.",
 			"severity": [],
 			"cwe_ids": ["CWE-79"],
 			"vulnerable_versions": [],
@@ -1818,7 +1818,7 @@ advisories = {
 			"osv_id": "CVE-2020-13326",
 			"published": "2020-09-29T18:45:49",
 			"aliases": [],
-			"summary": "A vulnerability was discovered in GitLab versions prior to 13.1. Under certain conditions the restriction for Github project import could be bypassed.",
+			"summary": "A vulnerability was discovered in GitLab versions prior to 13.1. Under certain conditions the restriction for GitHub project import could be bypassed.",
 			"severity": [{
 				"type": "CVSS_V3",
 				"score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N",

--- a/opa/rego/rules/github_action_from_unverified_creator_used.rego
+++ b/opa/rego/rules/github_action_from_unverified_creator_used.rego
@@ -1,5 +1,5 @@
 # METADATA
-# title: Github Action from Unverified Creator used
+# title: GitHub Action from Unverified Creator used
 # description: |-
 #   Usage of the following GitHub Actions repositories was detected in workflows
 #   or composite actions, but their owner is not a verified creator.

--- a/scanner/parsers.go
+++ b/scanner/parsers.go
@@ -51,7 +51,7 @@ func (p *GithubActionsMetadataParser) ParseFromMemory(data []byte, filePath stri
 		meta.Path = filePath
 		pkgInsights.GithubActionsMetadata = append(pkgInsights.GithubActionsMetadata, meta)
 	} else {
-		log.Debug().Str("file", filePath).Msg("invalid Github Actions metadata")
+		log.Debug().Str("file", filePath).Msg("invalid GitHub Actions metadata")
 	}
 
 	return nil

--- a/test/snapshot/__snapshots__/snapshot_test.snap
+++ b/test/snapshot/__snapshots__/snapshot_test.snap
@@ -522,7 +522,7 @@
    "description": "Usage of the following GitHub Actions repositories was detected in workflows\nor composite actions, but their owner is not a verified creator.",
    "id": "github_action_from_unverified_creator_used",
    "level": "note",
-   "title": "Github Action from Unverified Creator used"
+   "title": "GitHub Action from Unverified Creator used"
   },
   "if_always_true": {
    "description": "GitHub Actions expressions used in if condition of jobs or steps\nmust not contain extra characters or spaces.\nOtherwise, the condition is always true.",
@@ -982,7 +982,7 @@
    "description": "Usage of the following GitHub Actions repositories was detected in workflows\nor composite actions, but their owner is not a verified creator.",
    "id": "github_action_from_unverified_creator_used",
    "level": "note",
-   "title": "Github Action from Unverified Creator used"
+   "title": "GitHub Action from Unverified Creator used"
   },
   "if_always_true": {
    "description": "GitHub Actions expressions used in if condition of jobs or steps\nmust not contain extra characters or spaces.\nOtherwise, the condition is always true.",


### PR DESCRIPTION
This PR renames `Github` -> `GitHub`.