### PR TITLE
perf(formatters): hoist SCP git URL regex to package level in IsValidGitURL

### DIFF
--- a/formatters/sarif/sarif.go
+++ b/formatters/sarif/sarif.go
@@ -16,6 +16,8 @@ import (
 	"github.com/owenrumney/go-sarif/v2/sarif"
 )
 
+var sshPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+@[a-zA-Z0-9._-]+:[a-zA-Z0-9/._-]+$`)
+
 func NewFormat(out io.Writer, version string) *Format {
 	return &Format{
 		out:     out,
@@ -196,6 +198,5 @@ func IsValidGitURL(gitURL string) bool {
 		return parsedURL.Host != "" && parsedURL.Path != ""
 	}
 
-	sshPattern := regexp.MustCompile(`^[a-zA-Z0-9_-]+@[a-zA-Z0-9._-]+:[a-zA-Z0-9/._-]+$`)
 	return sshPattern.MatchString(gitURL)
 }


### PR DESCRIPTION
## Summary

- Move the SCP-style git URL regex (`user@host:repo`) from inside `IsValidGitURL` to a package-level `var`, so it is compiled once at init instead of on every call.
- No behavior change for HTTP(S), `ssh://`, or SCP URL validation.

## Benchmark

`BenchmarkIsValidGitURL` on Apple M4 Pro (darwin/arm64), 10 runs each:

| URL type   | Before        | After       | Change                          |
|------------|---------------|-------------|---------------------------------|
| HTTPS      | ~113 ns, 1 alloc  | ~112 ns, 1 alloc  | unchanged (expected)            |
| SSH-scheme | ~150 ns, 2 allocs | ~149 ns, 2 allocs | unchanged (expected)            |
| **SCP**    | **~2.6 µs, 5.6 KB, 75 allocs** | **~243 ns, 0 B, 0 allocs** | **~11× faster, zero heap allocs** |

The win is entirely on the SCP path (`git@github.com:user/repo`), which previously called `regexp.MustCompile` on every invocation.